### PR TITLE
Fix shared installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ tests: lib
 
 install: lib
 	$(MAKE) -C src install
+	$(MAKE) -C tests install
 
 docs:
 	$(MAKE) -C docs

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -15,10 +15,10 @@ endif
 
 
 CXXFLAGS += $(OPENMP)
-CPPFLAGS = $(GSL_CPPFLAGS) -I${KARIBA}
+CPPFLAGS += $(GSL_CPPFLAGS) -I${KARIBA}
 LD = $(CXX)
-LDFLAGS = $(OPENMP) $(GSL_LDFLAGS) $(EXTRA_LDFLAGS)
-LDLIBS = -lgsl -lgslcblas -lm
+LDFLAGS += $(OPENMP) $(GSL_LDFLAGS) $(EXTRA_LDFLAGS)
+LDLIBS += -lgsl -lgslcblas -lm
 RM = rm -f
 
 

--- a/examples/model/Makefile
+++ b/examples/model/Makefile
@@ -14,10 +14,10 @@ endif
 
 
 CXXFLAGS += $(OPENMP)
-CPPFLAGS = $(GSL_CPPFLAGS) -I${KARIBA}
+CPPFLAGS += $(GSL_CPPFLAGS) -I${KARIBA}
 LD = $(CXX)
-LDFLAGS = $(OPENMP) $(GSL_LDFLAGS) $(EXTRA_LDFLAGS)
-LDLIBS = -lgsl -lgslcblas -lm
+LDFLAGS += $(OPENMP) $(GSL_LDFLAGS) $(EXTRA_LDFLAGS)
+LDLIBS += -lgsl -lgslcblas -lm
 RM = rm -f
 
 

--- a/make.config-template
+++ b/make.config-template
@@ -14,14 +14,16 @@ GSL =
 # If you are using OpenMP, make sure the compiler is
 # OpenMP compatible, that is, it can handle the -fopenmp
 # option
-CXX = c++
+ifndef CXX
+       CXX = c++
+endif
 
 # Set compiler flags: standard, optimization level, warnings, etc Note
 # that -Ofast is deprecated by CLang++, and should be be `-O3
 # -ffast-math` instead; using only `-O3` is safer anyway.
 # The -fopenmp flag should not be set here, but specified using
 # the OPENMP variable below
-CXXFLAGS = -std=c++17 -Wall -Wextra -Wconversion -O3 -fPIC
+CXXFLAGS += -std=c++17 -Wall -Wextra -Wconversion -O3 -fPIC
 
 # Set the following variable to the -fopenmp to use OpenMP.
 # If unset or empty, OpenMP will not be used in the compilation

--- a/src/Makefile
+++ b/src/Makefile
@@ -56,9 +56,9 @@ else ifeq ($(UNAME), Linux)
 	$(LD) -shared -fPIC -o $(LIBSHARED) $(LDFLAGS) $(OBJECTS) $(LDLIBS) -Wl,-soname,$(LIBSHARED)
 endif
 
-install:
+install: shared
 	install -d $(DESTDIR)$(PREFIX)/lib/
-	install -m 644 libkariba.a $(LIBSHARED) $(DESTDIR)$(PREFIX)/lib/
+	install -m 644 libkariba.$(DYN_EXT) $(LIBSHARED) $(DESTDIR)$(PREFIX)/lib/
 	install -d $(DESTDIR)$(PREFIX)/include/kariba/
 	install -m 644 kariba/*.hpp $(DESTDIR)$(PREFIX)/include/kariba/
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -15,10 +15,10 @@ endif
 UNAME := $(shell uname -s)
 
 CXXFLAGS += $(OPENMP)
-CPPFLAGS = $(GSL_CPPFLAGS)
+CPPFLAGS += $(GSL_CPPFLAGS)
 LD = $(CXX)
-LDFLAGS = $(OPENMP) $(GSL_LDFLAGS) $(EXTRA_LDFLAGS)
-LDLIBS = -lgsl -lgslcblas -lm
+LDFLAGS += $(OPENMP) $(GSL_LDFLAGS) $(EXTRA_LDFLAGS)
+LDLIBS += -lgsl -lgslcblas -lm
 AR = ar
 AR_OPTS = rcs
 RM = rm -f

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -26,22 +26,16 @@ LDLIBS += -lgsl -lgslcblas -lm
 RM = rm -f
 
 
-# Platform specific stuff for building the shared library
-ifeq ($(UNAME_S), Darwin)  # macOS
-    RPATH = -Wl,-rpath,$(KARIBA)
-else ifeq ($(UNAME_S), Linux)
-    RPATH = -Wl,-rpath,$(KARIBA)
-endif
-
 # Kariba library
 LIBKARIBA = $(KARIBA)/libkariba.a
 LIBPATH = $(shell dirname $(realpath $(LIBKARIBA)))
-LIBSHARED = -L$(LIBPATH) -Wl,-rpath,$(LIBPATH) -lkariba
+#LIBSHARED = -L$(LIBPATH) -Wl,-rpath,$(LIBPATH) -lkariba
+LIBSHARED = -L$(DESTDIR)$(PREFIX)/lib -lkariba
 
 SOURCES = test_bknpower.cpp test_compton.cpp test_cyclosyn.cpp test_distributions.cpp test_ebl.cpp test_particles.cpp test_powerlaw.cpp test_radiation.cpp
 OBJECTS = $(subst .cpp,.o,$(SOURCES))
 MAIN_OBJ = test_main.cpp
-TEST_MAIN = test_main
+TEST_MAIN = kariba_test
 
 
 .PHONY: all tests main clean distclean
@@ -52,12 +46,15 @@ main: $(OBJECTS) $(MAIN_OBJ)
 	$(LD) -o $(TEST_MAIN) $(OBJECTS) $(MAIN_OBJ) $(LDFLAGS) $(LIBKARIBA) $(LDLIBS)
 
 # Unit tests that use the shared library version
-shared: $(OBJETS) $(MAIN_OBJ)
+shared: $(OBJECTS) $(MAIN_OBJ)
 	$(LD) -o $(TEST_MAIN) $(OBJECTS) $(MAIN_OBJ) $(LDFLAGS) $(LIBSHARED) $(LDLIBS)
 
+install: shared
+	install -d $(DESTDIR)$(PREFIX)/bin/
+	install -m 755 $(TEST_MAIN) $(DESTDIR)$(PREFIX)/bin/
 
 clean:
 	$(RM) $(OBJECTS)
 
 distclean: clean
-	$(RM) $(ALL_TESTS)
+	$(RM) $(TEST_MAIN)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -19,10 +19,10 @@ UNAME := $(shell uname -s)
 
 
 CXXFLAGS += $(OPENMP)
-CPPFLAGS = -I${GSL}/include -I${KARIBA} -I.
+CPPFLAGS += $(GSL_CPPFLAGS) -I${KARIBA} -I.
 LD = $(CXX)
-LDFLAGS = -L${GSL}/lib $(OPENMP) $(EXTRA_LDFLAGS)
-LDLIBS = -lgsl -lgslcblas -lm
+LDFLAGS += $(GSL_LDFLAGS) $(OPENMP) $(EXTRA_LDFLAGS)
+LDLIBS += -lgsl -lgslcblas -lm
 RM = rm -f
 
 


### PR DESCRIPTION
Create an installation with the shared version of the library. This is mostly for use within e.g. a Conda-forge package.