### PR TITLE
Update the Compton class to be more flexible and easier to read, fix discretization issue (r->z), ssa-timescale readout, smooth mixed PL cuton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 *.dat
 
 make.config
+
+.DS_Store

--- a/src/Compton.cpp
+++ b/src/Compton.cpp
@@ -72,8 +72,8 @@ Compton::~Compton() {
 }
 
 Compton::Compton(size_t size, size_t target_size)
-    : Radiation(size), target_energy(target_size, 0.0), log_target_diff_spec(target_size, -230), 
-      log_target_diff_spec_iter(size, -230) {
+    : Radiation(size), target_energy(target_size, 0.0), log_target_diff_spec(target_size, log_floor), 
+      log_target_diff_spec_iter(size, log_floor) {
     en_phot_obs.resize(en_phot_obs.size() * 2, 0.0);
     num_phot_obs.resize(num_phot_obs.size() * 2, 0.0);
 
@@ -232,7 +232,7 @@ void Compton::compton_spectrum(double gmin, double gmax, gsl_spline* eldis,
                 num_phot_obs[i + size] = 0.0;
             }
             if (com == 0) {
-                log_target_diff_spec_iter[i] = -230;
+                log_target_diff_spec_iter[i] = log_floor;
             } else {
                 if (geometry == "cylinder"){
                     log_target_diff_spec_iter[i] = log(escape_corr * com * vol /
@@ -252,7 +252,7 @@ void Compton::compton_spectrum(double gmin, double gmax, gsl_spline* eldis,
 //! Method to set new target energy array, resets also log_target_diff_spec
 void Compton::set_target_energy_array(const std::vector<double>& new_target_energy) {
     target_energy = new_target_energy;
-    log_target_diff_spec = std::vector<double>(new_target_energy.size(), -230);
+    log_target_diff_spec = std::vector<double>(new_target_energy.size(), log_floor);
     gsl_spline_free(seed_ph);
     seed_ph = gsl_spline_alloc(gsl_interp_steffen, target_energy.size());
 }
@@ -262,7 +262,7 @@ void Compton::set_target_frequency_array(const std::vector<double>& new_target_f
     for (size_t i = 0; i < new_target_frequency.size(); i++) {
         target_energy[i] = new_target_frequency[i] * constants::herg;
     }
-    log_target_diff_spec = std::vector<double>(new_target_frequency.size(), -230);
+    log_target_diff_spec = std::vector<double>(new_target_frequency.size(), log_floor);
     gsl_spline_free(seed_ph);
     seed_ph = gsl_spline_alloc(gsl_interp_steffen, target_energy.size());
 }
@@ -278,8 +278,6 @@ void Compton::add_target_diff_spec(
         // Guard against numerical issues for very small sums
         if (sum_lin > 0.0) {
             log_target_diff_spec[i] = log(sum_lin);
-        } else {
-            // keep old value
         }
     }
     
@@ -401,7 +399,7 @@ void Compton::bb_seed_k(double Urad, double Tbb) {
                       (constants::herg * pow(constants::cee, 2.) * constants::sbconst *
                        pow(Tbb, 4) * (exp(energy / (constants::kboltz * Tbb)) - 1.));
         } else {
-            bb_diff_spec[i] = 1.e-100;
+            bb_diff_spec[i] = 1e-100;
         }
     }
     add_target_diff_spec(bb_diff_spec);
@@ -576,7 +574,7 @@ std::vector<double> Compton::get_target_diff_spec(){
 //! This resets the energy density in case different photon fields want to be
 //! calculated separately to see the contribution of each
 void Compton::reset() {
-    std::fill(log_target_diff_spec.begin(), log_target_diff_spec.end(), -230);
+    std::fill(log_target_diff_spec.begin(), log_target_diff_spec.end(), log_floor);
     std::fill(target_energy.begin(), target_energy.end(), 0);
     std::fill(num_phot.begin(), num_phot.end(), 0);
     std::fill(num_phot_obs.begin(), num_phot_obs.end(), 0);

--- a/src/Compton.cpp
+++ b/src/Compton.cpp
@@ -236,10 +236,10 @@ void Compton::compton_spectrum(double gmin, double gmax, gsl_spline* eldis,
                 log_target_diff_spec_iter[i] = -50;
             } else {
                 if (geometry == "cylinder"){
-                    log_target_diff_spec_iter[i] = log10(escape_corr * com * vol /
+                    log_target_diff_spec_iter[i] = log(escape_corr * com * vol /
                                           (constants::pi * r * z * constants::cee));
                 } else {
-                    log_target_diff_spec_iter[i] = log10(escape_corr * com * vol /
+                    log_target_diff_spec_iter[i] = log(escape_corr * com * vol /
                                           (constants::pi * pow(r, 2.) * constants::cee));
                 }
             }
@@ -254,7 +254,7 @@ void Compton::compton_spectrum(double gmin, double gmax, gsl_spline* eldis,
 void Compton::set_target_energy_array(const std::vector<double>& new_target_energy) {
     log_target_energy = std::vector<double>(new_target_energy.size());
     for (size_t i = 0; i < new_target_energy.size(); i++) {
-        log_target_energy[i] = log10(new_target_energy[i]);
+        log_target_energy[i] = log(new_target_energy[i]);
     }
     log_target_diff_spec = std::vector<double>(new_target_energy.size(), -100);
     gsl_spline_free(seed_ph);
@@ -264,7 +264,7 @@ void Compton::set_target_energy_array(const std::vector<double>& new_target_ener
 void Compton::set_target_frequency_array(const std::vector<double>& new_target_frequency) {
     log_target_energy = std::vector<double>(new_target_frequency.size());
     for (size_t i = 0; i < new_target_frequency.size(); i++) {
-        log_target_energy[i] = log10(new_target_frequency[i] * constants::herg);
+        log_target_energy[i] = log(new_target_frequency[i] * constants::herg);
     }
     log_target_diff_spec = std::vector<double>(new_target_frequency.size(), -100);
     gsl_spline_free(seed_ph);

--- a/src/Compton.cpp
+++ b/src/Compton.cpp
@@ -265,6 +265,32 @@ void Compton::cyclosyn_seed(const std::vector<double>& seed_arr,
     gsl_spline_init(seed_ph, seed_energ.data(), seed_urad.data(), seed_energ.size());
 }
 
+void Compton::add_seed(const std::vector<double>& seed_syn_energ, const std::vector<double>& seed_arr) {
+    double emin, emax, urad;
+
+    emin = seed_energ[0];
+    emax = seed_energ[seed_energ.size()-1];
+    // seed_freq_array(seed_arr);
+    // seed_energ = seed_arr;
+
+    for (size_t i = 0; i < seed_syn_energ.size(); i++) {
+        if (seed_syn_energ[i] < emin) {
+            urad = 1.e-100;
+        } else if (seed_syn_energ[i] < emax) {
+            urad = seed_arr[i];
+        } else {
+            urad = 1.e-100;
+        }
+        if (seed_urad[i] != 0) {
+            seed_urad[i] = std::log10(std::pow(10., seed_urad[i]) + urad);
+        } else if (urad > 0) {
+            seed_urad[i] = std::log10(urad);
+        } else {
+            seed_urad[i] = -100;
+        }
+    }
+    gsl_spline_init(seed_ph, seed_energ.data(), seed_urad.data(), seed_energ.size());
+}
 //! Method to include black body to seed field for IC;
 //! Note: Urad and Tbb need to be passed in the co-moving frame, the function
 //! does NOT account for beaming

--- a/src/Compton.cpp
+++ b/src/Compton.cpp
@@ -556,11 +556,11 @@ void Compton::set_frequency(double numin, double numax) {
 void Compton::set_escape(double escape) { escape_corr = escape; }
 
 
-std::vector<double> Compton::get_target_energy(){
+std::vector<double> Compton::get_target_energy() const {
     return target_energy;
 }
 
-std::vector<double> Compton::get_target_diff_spec(){
+std::vector<double> Compton::get_target_diff_spec() const {
     std::vector<double> vals(log_target_diff_spec.size(), 0.);
     for (size_t i = 0; i < log_target_diff_spec.size(); i++)
     {

--- a/src/Compton.cpp
+++ b/src/Compton.cpp
@@ -65,12 +65,18 @@ Compton::~Compton() {
 
     gsl_spline_free(iter_ph);
     gsl_interp_accel_free(acc_iter);
+
+    gsl_integration_workspace_free(w1);
+    gsl_integration_workspace_free(w2);
+
 }
 
-Compton::Compton(size_t size, size_t seed_size)
-    : Radiation(size), seed_energ(seed_size, 0.0), seed_urad(seed_size, 0.0), iter_urad(size, 0.0) {
+Compton::Compton(size_t size, size_t target_size)
+    : Radiation(size), log_target_energy(target_size, 0.0), log_target_diff_spec(target_size, 0.0), 
+      log_target_diff_spec_iter(size, 0.0) {
     en_phot_obs.resize(en_phot_obs.size() * 2, 0.0);
     num_phot_obs.resize(num_phot_obs.size() * 2, 0.0);
+    log_energy_iter.resize(en_phot.size(), -100.);
 
     Niter = 20;
     ypar = 0;
@@ -86,17 +92,21 @@ Compton::Compton(size_t size, size_t seed_size)
     gsl_spline2d_init(esc_p_sph, Te_table, tau_table, esc_table_sph, 15, 15);
     gsl_spline2d_init(esc_p_cyl, Te_table, tau_table, esc_table_cyl, 15, 15);
 
-    seed_ph = gsl_spline_alloc(gsl_interp_steffen, seed_energ.size());
+    seed_ph = gsl_spline_alloc(gsl_interp_steffen, log_target_energy.size());
     acc_seed = gsl_interp_accel_alloc();
 
     iter_ph = gsl_spline_alloc(gsl_interp_steffen, en_phot.size());
     acc_iter = gsl_interp_accel_alloc();
+
+    // integration workspaces
+    w1 = gsl_integration_workspace_alloc(100);
+    w2 = gsl_integration_workspace_alloc(100);
 }
 
 //! This function is the kernel of eq 2.48 in Blumenthal & Gould(1970),
 //! represents the scattered photon spectrum for a given electron and includes
 //! the Klein-Nishina cross section.
-double comfnc(double ein, void* pars) {
+double comfnc(double logein, void* pars) {
     ComfncParams* params = static_cast<ComfncParams*>(pars);
     double game = params->game;
     double e1 = params->e1;
@@ -108,7 +118,7 @@ double comfnc(double ein, void* pars) {
     double tm1, tm2, tm3;
     double btst, eg4;
 
-    einit = std::exp(ein);
+    einit = exp(logein);
     btst = einit / (game * constants::emerg);
     eg4 = 4. * einit * game;
     utst = eg4 / (constants::emerg + eg4);
@@ -118,11 +128,11 @@ double comfnc(double ein, void* pars) {
     } else {
         biggam = eg4 / constants::emerg;
         q = e1 / (biggam * (1. - e1));
-        phonum = gsl_spline_eval(phodis, einit, acc_phodis);
-        tm1 = 2. * q * std::log(q);
+        phonum = exp(gsl_spline_eval(phodis, logein, acc_phodis));
+        tm1 = 2. * q * log(q);
         tm2 = (1. + 2. * q) * (1. - q);
-        tm3 = 0.5 * (std::pow(biggam * q, 2.) * (1. - q)) / (1. + biggam * q);
-        return (tm1 + tm2 + tm3) * std::pow(10., phonum);
+        tm3 = 0.5 * (pow(biggam * q, 2.) * (1. - q)) / (1. + biggam * q);
+        return (tm1 + tm2 + tm3) * phonum;
     }
 }
 
@@ -138,29 +148,26 @@ double comint(double gam, void* pars) {
     gsl_spline* phodis = (params->phodis);
     gsl_interp_accel* acc_phodis = (params->acc_phodis);
 
-    double game, econst, blim, ulim, e1, den;
+    double game, econst, blim, ulim, e1, elden;
     double result, error;
 
     game = exp(gam);
     e1 = eph / (game * constants::emerg);
     econst = 2. * constants::pi * constants::re0 * constants::re0 * constants::cee;
-    blim = std::log(std::max(eph / (4. * game * (game - eph / constants::emerg)), ephmin));
-    ulim = std::log(std::min(eph, ephmax));
+    blim = log(std::max(eph / (4. * game * (game - eph / constants::emerg)), ephmin));
+    ulim = log(std::min(eph, ephmax));
 
     if (ulim <= blim) {
         return 0;
     } else {
-        gsl_integration_workspace* w2;
-        w2 = gsl_integration_workspace_alloc(100);
         gsl_function F2;
         auto F2params = ComfncParams{game, e1, phodis, acc_phodis};
         F2.function = &comfnc;
         F2.params = &F2params;
         gsl_integration_qag(&F2, blim, ulim, 1e0, 1e0, 100, 2, w2, &result, &error);
-        gsl_integration_workspace_free(w2);
-
-        den = gsl_spline_eval(eldis, game, acc_eldis);
-        return econst * den * result / game;
+        
+        elden = gsl_spline_eval(eldis, game, acc_eldis);
+        return econst * elden * result / game;
     }
 }
 
@@ -169,8 +176,6 @@ double comint(double gam, void* pars) {
 double Compton::comintegral(size_t it, double blim, double ulim, double enphot, double enphmin,
                             double enphmax, gsl_spline* eldis, gsl_interp_accel* acc_eldis) {
     double result, error;
-    gsl_integration_workspace* w1;
-    w1 = gsl_integration_workspace_alloc(100);
 
     gsl_function F1;
     auto F1params = ComintParams{enphot, enphmin, enphmax, eldis, acc_eldis, seed_ph, acc_seed};
@@ -185,7 +190,7 @@ double Compton::comintegral(size_t it, double blim, double ulim, double enphot, 
     // instead of 1 makes for smoother integrals. Not important for the final
     // spectrum, but it makes for better-looking and more accurate plots
     gsl_integration_qag(&F1, blim, ulim, 1e0, 1e0, 100, 2, w1, &result, &error);
-    gsl_integration_workspace_free(w1);
+    
 
     return result;
 }
@@ -200,16 +205,17 @@ void Compton::compton_spectrum(double gmin, double gmax, gsl_spline* eldis,
     double dopfac_cj;
     double ephmin, ephmax;
 
-    ephmin = seed_energ.front();    //[0];
-    ephmax = seed_energ.back();     //[seed_size - 1];
+    ephmin = pow(10., lg_target_energy.front());    //[0];
+    ephmax = pow(10., lg_target_energy.back());     //[target_size - 1];
 
     dopfac_cj = dopfac * (1. - beta * cos(angle)) / (1. + beta * cos(angle));
 
     size_t size = en_phot.size();
     for (size_t it = 0; it < Niter; it++) {
         for (size_t i = 0; i < size; i++) {
-            blim = std::log(std::max(gmin, en_phot[i] / constants::emerg));
-            ulim = std::log(gmax);
+            if (it==0) log_energy_iter[i] = log(en_phot[i]);
+            blim = log(std::max(gmin, en_phot[i] / constants::emerg));
+            ulim = log(gmax);
             if (blim >= ulim) {
                 com = 1e-100;
             } else {
@@ -217,137 +223,192 @@ void Compton::compton_spectrum(double gmin, double gmax, gsl_spline* eldis,
             }
             num_phot[i] = num_phot[i] + com * vol * en_phot[i] * constants::herg;
             en_phot_obs[i] = en_phot[i] * dopfac;
-            num_phot_obs[i] = num_phot[i] * std::pow(dopfac, dopnum);
+            num_phot_obs[i] = num_phot[i] * pow(dopfac, dopnum);
             if (counterjet == true) {
                 en_phot_obs[i + size] = en_phot[i] * dopfac_cj;
-                num_phot_obs[i + size] = num_phot[i] * std::pow(dopfac_cj, dopnum);
+                num_phot_obs[i + size] = num_phot[i] * pow(dopfac_cj, dopnum);
             } else {
                 en_phot_obs[i + size] = 0.0;
                 num_phot_obs[i + size] = 0.0;
             }
             if (com == 0) {
-                iter_urad[i] = -50;
+                log_target_diff_spec_iter[i] = -50;
             } else {
                 if (geometry == "cylinder"){
-                    iter_urad[i] = std::log10(escape_corr * com * vol /
+                    log_target_diff_spec_iter[i] = log10(escape_corr * com * vol /
                                           (constants::pi * r * z * constants::cee));
                 } else {
-                    iter_urad[i] = std::log10(escape_corr * com * vol /
-                                          (constants::pi * std::pow(r, 2.) * constants::cee));
+                    log_target_diff_spec_iter[i] = log10(escape_corr * com * vol /
+                                          (constants::pi * pow(r, 2.) * constants::cee));
                 }
             }
         }
         ephmin = en_phot.front();    // [0];
         ephmax = en_phot.back();     //[size - 1];
-        gsl_spline_init(iter_ph, en_phot.data(), iter_urad.data(), size);
+        gsl_spline_init(iter_ph, log_energy_iter.data(), log_target_diff_spec_iter.data(), size);
     }
 }
+
+//! Method to set new target energy array, resets also lg_target_diff_spec
+void Compton::set_target_energy_array(const std::vector<double>& new_target_energy) {
+    lg_target_energy = log10(new_target_energy);
+    lg_target_diff_spec = std::vector<double>(new_target_energy.size(), -100);
+    gsl_spline_free(seed_ph);
+    seed_ph = gsl_spline_alloc(gsl_interp_steffen, lg_target_energy.size());
+}
+//! Method to set target energy array from frequency array, resets also lg_target_diff_spec
+void Compton::set_target_frequency_array(const std::vector<double>& new_target_frequency) {
+    lg_target_energy = std::vector<double>(new_target_frequency.size());
+    // to do: asssert input and member sizes are the same
+    for (size_t i = 0; i < new_target_frequency.size(); i++) {
+        lg_target_energy[i] = log10(new_target_frequency[i] * constants::herg);
+    }
+    lg_target_diff_spec = std::vector<double>(new_target_frequency.size(), -100);
+    gsl_spline_free(seed_ph);
+    seed_ph = gsl_spline_alloc(gsl_interp_steffen, lg_target_energy.size());
+}
+
+// adds target and updates spline, assumes ame energy grid
+void Compton::add_target_diff_spec(
+    const std::vector<double>& new_target_diff_spec) {
+        
+    for (size_t i = 0; i < new_target_diff_spec.size(); ++i) {
+
+        const double sum_lin = exp(log_target_diff_spec[i]) + new_target_diff_spec[i];
+
+        // Guard against numerical issues for very small sums
+        if (sum_lin > 0.0) {
+            log_target_diff_spec[i] = log(sum_lin);
+        } else {
+            // keep old value
+        }
+    }
+    
+    gsl_spline_init(seed_ph, log_target_energy.data(), log_target_diff_spec.data(), log_target_energy.size());
+}
+
+// adds target, cuts off outside energy boundaries, interpolates inbetween
+void Compton::add_target_energy_density(
+    const std::vector<double>& new_target_energy,
+    const std::vector<double>& new_target_energy_density
+) {
+
+    if (new_target_energy.size() != new_target_energy_density.size()) {
+        throw std::invalid_argument("new_target_energy and new_target_energy_density must have same size");
+    }
+    if (new_target_energy.size() < 2) {
+        // nothing sensible to interpolate
+        std::cout << "new_target_energy.size() < 2 -> nothing added!" << std::endl;
+        return;
+    }
+
+    // GSL interpolation structures 
+    gsl_interp_accel* acc_add_target = gsl_interp_accel_alloc();
+    gsl_spline* spline_add_target = gsl_spline_alloc(gsl_interp_steffen, new_target_energy.size());
+
+    std::vector<double> log_new_target_energy(new_target_energy.size());
+    std::vector<double> log_new_target_diff_spec(new_target_energy_density.size());
+    for (size_t i = 0; i < new_target_energy.size(); ++i) {
+        log_new_target_energy[i] = log(new_target_energy[i]);
+        log_new_target_diff_spec[i] = log(new_target_energy_density[i] / pow(new_target_energy, 2.));
+    }
+
+    // x = log(E), y = log(E-density)
+    gsl_spline_init(spline_add_target,
+                    log_new_target_energy.data(),
+                    log_new_target_diff_spec.data(),
+                    log_new_target_energy.size());
+
+    const double x_min = log_new_target_energy.front();
+    const double x_max = log_new_target_energy.back();
+
+    std::vector<double> interp_log_new_target_diff_spec(log_target_energy.size());
+    for (size_t i = 0; i < log_target_energy.size(); ++i) {
+        const double x = log_target_energy[i];
+
+        // If outside new grid → contribution is zero, so do nothing.
+        if (x < x_min || x > x_max) {
+            continue;
+        }
+
+        // Interpolate log(E-density_new) at this log(E)
+        interp_new_target_diff_spec[i] = std:exp(gsl_spline_eval(spline_add_target, x, acc_add_target));
+    }
+
+    gsl_spline_free(spline_add_target);
+    gsl_interp_accel_free(acc_add_target);
+    add_target_diff_spec(interp_new_target_diff_spec);
+}
+
+// adds target, cuts off outside energy boundaries, interpolates inbetween
+void Compton::add_target_number_density(
+    const std::vector<double>& new_target_energy,
+    const std::vector<double>& new_target_number_density
+) {
+    std::vector<double> new_target_energy_density(new_target_number_density.size());
+    for (size_t i = 0; i < new_target_number_density.size(); ++i) {
+        new_target_energy_density[i] = new_target_number_density[i] * new_target_energy[i];
+    }
+    add_target_energy_density(new_target_energy, new_target_energy_density);
+}
+
+// adds target, cuts off outside energy boundaries, interpolates inbetween
+void Compton::add_target_number_density_on_freq_grid(
+    const std::vector<double>& new_target_frequency,
+    const std::vector<double>& new_target_number_density
+) {
+    std::vector<double> new_target_energy(new_target_frequency.size());
+    std::vector<double> new_target_energy_density(new_target_number_density.size());
+    for (size_t i = 0; i < new_target_frequency.size(); ++i) {
+        new_target_energy[i] = new_target_frequency[i] * constants::herg;
+        new_target_energy_density[i] = new_target_number_density[i] * new_target_energy[i];
+    }
+    add_target_energy_density(new_target_energy, new_target_energy_density);
+}
+
 
 //! Method to include cyclosynchrotron array from Cyclosyn.hh to the seed field.
 //! The two input arrays should be get_energ() and get_nphot() methods from
-//! Cyclosyn.hh. If the seed_urad array wasn't empty, the contribution is
+//! Cyclosyn.hh. If the target_diff_spec array wasn't empty, the contribution is
 //! automatically added to the existing one. note: the second condition has a <=
 //! sign to dodge numerical errors when the seed field energy density is
-//! extremely low, which can result in negative values/nan for the seed_urad
-void Compton::cyclosyn_seed(const std::vector<double>& seed_arr,
-                            const std::vector<double>& seed_lum) {
-    // to do: asssert input and member sizes are the same
-    double new_val;
-    for (size_t i = 0; i < seed_arr.size(); i++) {
-        seed_energ[i] = seed_arr[i];
-        new_val = seed_lum[i] / (constants::cee * constants::herg *
-                                    seed_energ[i] * constants::pi * r * r);
-        if (seed_urad[i] != 0) {
-            seed_urad[i] = std::log10(std::pow(10., seed_urad[i]) + new_val);
-        } else if (new_val <= 0) {
-            seed_urad[i] = -100;
-        } else {
-            seed_urad[i] = std::log10(new_val);
-        }
+//! extremely low, which can result in negative values/nan for the target_diff_spec
+void Compton::cyclosyn_seed(const std::vector<double>& syn_frequencies,
+                            const std::vector<double>& syn_number_densities) {
+    set_target_frequency_array(syn_frequencies);
+
+    std::vector<double> new_target_diff_spec(syn_number_densities.size());
+    for (size_t i = 0; i < syn_number_densities.size(); ++i) {
+        new_target_diff_spec[i] = syn_number_densities[i] / (syn_frequencies[i] * constants::herg);
     }
-    gsl_spline_init(seed_ph, seed_energ.data(), seed_urad.data(), seed_energ.size());
+    add_target_diff_spec(new_target_diff_spec);
 }
 
-void Compton::add_seed(const std::vector<double>& seed_syn_energ, const std::vector<double>& seed_energy_density) {
-    double emin, emax, urad;
 
-    emin = seed_energ[0];
-    emax = seed_energ[seed_energ.size()-1];
-    // seed_freq_array(seed_arr);
-    // seed_energ = seed_arr;
-
-    for (size_t i = 0; i < seed_syn_energ.size(); i++) {
-        if (seed_syn_energ[i] < emin) {
-            urad = 1.e-100;
-        } else if (seed_syn_energ[i] < emax) {
-            urad = seed_energy_density[i]/seed_syn_energ[i]/seed_syn_energ[i];
-        } else {
-            urad = 1.e-100;
-        }
-        if (seed_urad[i] != 0) {
-            seed_urad[i] = std::log10(std::pow(10., seed_urad[i]) + urad);
-        } else if (urad > 0) {
-            seed_urad[i] = std::log10(urad);
-        } else {
-            seed_urad[i] = -100;
-        }
-    }
-    gsl_spline_init(seed_ph, seed_energ.data(), seed_urad.data(), seed_energ.size());
-}
 //! Method to include black body to seed field for IC;
 //! Note: Urad and Tbb need to be passed in the co-moving frame, the function
 //! does NOT account for beaming
-void Compton::bb_seed_k(const std::vector<double>& seed_arr, double Urad, double Tbb) {
-    double ulim, bbfield;
+void Compton::bb_seed_k(double Urad, double Tbb) {
+    double ulim, energy;
+    std::vector<double> bb_diff_spec(log_target_energy.size(), 1e-100);
 
-    ulim = 1e2 * Tbb * constants::kboltz;
-    // seed_freq_array(seed_arr);
-    seed_energ = seed_arr;
-
-    for (size_t i = 0; i < seed_arr.size(); i++) {
-        if (seed_energ[i] < ulim) {
-            bbfield = (2. * Urad * std::pow(seed_energ[i] / constants::herg, 2.)) /
-                      (constants::herg * std::pow(constants::cee, 2.) * constants::sbconst *
-                       std::pow(Tbb, 4) * (exp(seed_energ[i] / (constants::kboltz * Tbb)) - 1.));
+    ulim = log(3e2 * Tbb * constants::kboltz);
+    
+    for (size_t i = 0; i < log_target_energy.size(); i++) {
+        if (log_target_energy[i] < ulim) {
+            energy = exp(log_target_energy[i]);
+            bb_diff_spec[i] = (2. * Urad * pow(energy / constants::herg, 2.)) /
+                      (constants::herg * pow(constants::cee, 2.) * constants::sbconst *
+                       pow(Tbb, 4) * (exp(energy / (constants::kboltz * Tbb)) - 1.));
         } else {
-            bbfield = 1.e-100;
-        }
-        if (seed_urad[i] != 0) {
-            seed_urad[i] = std::log10(std::pow(10., seed_urad[i]) + bbfield);
-        } else if (bbfield > 0) {
-            seed_urad[i] = std::log10(bbfield);
-        } else {
-            seed_urad[i] = -100;
+            bb_diff_spec[i] = 1.e-100;
         }
     }
-    gsl_spline_init(seed_ph, seed_energ.data(), seed_urad.data(), seed_energ.size());
+    add_target_diff_spec(bb_diff_spec);
 }
 
-void Compton::bb_seed_kev(const std::vector<double>& seed_arr, double Urad, double Tbb) {
-    double ulim, bbfield;
-
-    ulim = 1e2 * Tbb * constants::kboltz_kev2erg;
-    // seed_freq_array(seed_arr);
-    seed_energ = seed_arr;
-
-    for (size_t i = 0; i < seed_arr.size(); i++) {
-        if (seed_energ[i] < ulim) {
-            bbfield = (2. * Urad * std::pow(seed_energ[i] / constants::herg, 2.)) /
-                      (constants::herg * std::pow(constants::cee, 2.) * constants::sbconst *
-                       std::pow(Tbb * constants::kboltz_kev2erg / constants::kboltz, 4) *
-                       (exp(seed_energ[i] / (Tbb * constants::kboltz_kev2erg)) - 1.));
-        } else {
-            bbfield = 1.e-100;
-        }
-        if (seed_urad[i] != 0) {
-            seed_urad[i] = std::log10(std::pow(10., seed_urad[i]) + bbfield);
-        } else if (bbfield > 0) {
-            seed_urad[i] = std::log10(bbfield);
-        } else {
-            seed_urad[i] = -100;
-        }
-    }
-    gsl_spline_init(seed_ph, seed_energ.data(), seed_urad.data(), seed_energ.size());
+void Compton::bb_seed_kev(double Urad, double Tbb) {
+    bb_seed_k(Urad, Tbb * constants::kboltz_kev2erg/constants::kboltz);
 }
 
 //! Calculates incident photon field for a Shakura-Sunyaev disk with aspect ratio
@@ -373,22 +434,22 @@ double disk_integral(double alfa, void* pars) {
     x = a / b;
     y = x / tan(alfa) + z;
 
-    r = std::pow(std::pow(x, 2.) + std::pow(y, 2.), 1. / 2.);
-    T_eff = delta * tin * std::pow(rin / r, 0.75);
+    r = pow(pow(x, 2.) + pow(y, 2.), 1. / 2.);
+    T_eff = delta * tin * pow(rin / r, 0.75);
     nu_eff = delta * nu;
     fac = (constants::herg * nu_eff) / (constants::kboltz * T_eff);
 
-    Urad = 4. * constants::pi * std::pow(nu_eff, 2.) /
-           (constants::herg * std::pow(constants::cee, 3.) * (exp(fac) - 1.));
+    Urad = 4. * constants::pi * pow(nu_eff, 2.) /
+           (constants::herg * pow(constants::cee, 3.) * (exp(fac) - 1.));
 
     return Urad;
 }
 
-void Compton::shsdisk_seed(const std::vector<double>& seed_arr, double tin, double rin, double rout,
-                           double h, double z) {
-    double ulim, blim, nulim, Gamma, result, error, diskfield;
+void Compton::shsdisk_seed(double tin, double rin, double rout, double h, double z) {
+    double ulim, blim, logElim, Gamma, result, error;
+    std::vector<double> disk_diff_spec(log_target_energy.size(), 1e-100);
 
-    Gamma = 1. / std::pow((1. - std::pow(beta, 2.)), 1. / 2.);
+    Gamma = 1. / pow((1. - pow(beta, 2.)), 1. / 2.);
 
     blim = atan(rin / z);
     if (z < h * rout / 2.) {
@@ -396,35 +457,23 @@ void Compton::shsdisk_seed(const std::vector<double>& seed_arr, double tin, doub
     } else {
         ulim = atan(rout / (z - h * rout / 2.));
     }
-    nulim = 1e1 * tin * constants::kboltz;
-    // seed_freq_array(seed_arr);
-    seed_energ = seed_arr;
+    logElim = log(1e1 * tin * constants::kboltz);
 
-    for (size_t i = 0; i < seed_energ.size(); i++) {
-        if (seed_energ[i] < nulim) {
-            gsl_integration_workspace* w1;
-            w1 = gsl_integration_workspace_alloc(100);
+    for (size_t i = 0; i < log_target_energy.size(); i++) {
+        if (log_target_energy[i] < logElim) {
             gsl_function F;
             auto Fparams =
-                DiskIcParams{Gamma, beta, tin, rin, rout, h, z, seed_energ[i] / constants::herg};
+                DiskIcParams{Gamma, beta, tin, rin, rout, h, z, exp(log_target_energy[i] / constants::herg)};
             F.function = &disk_integral;
             F.params = &Fparams;
             gsl_integration_qag(&F, blim, ulim, 0, 1e-5, 100, 2, w1, &result, &error);
-            gsl_integration_workspace_free(w1);
 
-            diskfield = result;
+            disk_diff_spec[i] = result;
         } else {
-            diskfield = 1.e-100;
-        }
-        if (seed_urad[i] != 0) {
-            seed_urad[i] = std::log10(std::pow(10., seed_urad[i]) + diskfield);
-        } else if (diskfield > 0) {
-            seed_urad[i] = std::log10(diskfield);
-        } else {
-            seed_urad[i] = -100;
+            disk_diff_spec[i] = 1.e-100;
         }
     }
-    gsl_spline_init(seed_ph, seed_energ.data(), seed_urad.data(), seed_energ.size());
+    add_target_diff_spec(disk_diff_spec);
 }
 
 //! Method to estimate the number of scatterings the electrons go through;
@@ -439,7 +488,7 @@ void Compton::set_niter(double nu0, double Te) {
 
     x0 = constants::herg * nu0 / constants::emerg;
     xf = Te / constants::emerg;
-    k = std::log(xf / x0);
+    k = log(xf / x0);
     Niter = static_cast<size_t>(k + 0.5);
 }
 
@@ -454,7 +503,7 @@ void Compton::set_tau(double n, double Te) {
 
     theta = Te * constants::kboltz_kev2erg / constants::emerg;
     tau = n * r * constants::sigtom;
-    ypar = std::max(tau * tau, tau) * (std::pow(4.0 * theta, 1) + std::pow(4.0 * theta, 2));
+    ypar = std::max(tau * tau, tau) * (pow(4.0 * theta, 1) + pow(4.0 * theta, 2));
     rphot = 1. / (n * constants::sigtom);
 
     // set up the radiative transfer correction (first two ifs), and handle out
@@ -485,9 +534,9 @@ void Compton::set_tau(double n, double Te) {
     }
     // set up the photopshere correction if optical depth greater than 1
     if (geometry == "sphere" && tau > 1.) {
-        vol = (4. / 3.) * constants::pi * (std::pow(r, 3.) - std::pow(r - rphot, 3.));
+        vol = (4. / 3.) * constants::pi * (pow(r, 3.) - pow(r - rphot, 3.));
     } else if (geometry == "cylinder" && tau > 1.) {
-        vol = constants::pi * z * (std::pow(r, 2.) - std::pow(r - rphot, 2.));
+        vol = constants::pi * z * (pow(r, 2.) - pow(r - rphot, 2.));
     }
 }
 
@@ -496,11 +545,11 @@ void Compton::set_tau(double _tau) { tau = _tau; }
 //! Method to set up the frequency array over desired range
 void Compton::set_frequency(double numin, double numax) {
     double nuinc =
-        (std::log10(numax) - std::log10(numin)) / static_cast<double>(en_phot.size() - 1);
+        (log10(numax) - log10(numin)) / static_cast<double>(en_phot.size() - 1);
 
     for (size_t i = 0; i < en_phot.size(); i++) {
         en_phot[i] =
-            std::pow(10., std::log10(numin) + static_cast<double>(i) * nuinc) * constants::herg;
+            pow(10., log10(numin) + static_cast<double>(i) * nuinc) * constants::herg;
     }
 }
 
@@ -508,26 +557,34 @@ void Compton::set_frequency(double numin, double numax) {
 //! geometry
 void Compton::set_escape(double escape) { escape_corr = escape; }
 
-//! Method to set up seed frequency array
-void Compton::seed_freq_array(const std::vector<double>& seed_arr) {
-    // to do: asssert input and member sizes are the same
-    for (size_t i = 0; i < seed_arr.size(); i++) {
-        seed_energ[i] = seed_arr[i];
-    }
+
+std::vector<double> Compton::get_target_energy(){
+    return exp(log_target_energy);
 }
+
+std::vector<double> Compton::get_target_diff_spec(){
+    std::vector<double> vals(log_target_diff_spec.size(), 0.);
+    for (size_t i = 0; i < log_target_diff_spec.size(); i++)
+    {
+        vals[i] = exp(log_target_diff_spec[i]);
+    }
+    
+    return vals;
+}
+
 
 //! This resets the energy density in case different photon fields want to be
 //! calculated separately to see the contribution of each
 void Compton::reset() {
-    std::fill(seed_urad.begin(), seed_urad.end(), 0);
-    std::fill(seed_energ.begin(), seed_energ.end(), 0);
+    std::fill(lg_target_diff_spec.begin(), lg_target_diff_spec.end(), 0);
+    std::fill(lg_target_energy.begin(), lg_target_energy.end(), 0);
     std::fill(num_phot.begin(), num_phot.end(), 0);
     std::fill(num_phot_obs.begin(), num_phot_obs.end(), 0);
 }
 
 void Compton::urad_test() {
-    for (size_t i = 0; i < seed_energ.size(); i++) {
-        std::cout << seed_energ[i] / constants::herg << " " << seed_urad[i] << " " << iter_urad[i]
+    for (size_t i = 0; i < lg_target_energy.size(); i++) {
+        std::cout << exp(log_target_energy[i]) / constants::herg << " " << exp(log_target_diff_spec[i]) << " " << exp(log_target_diff_spec_iter)[i]
                   << std::endl;
     }
 }
@@ -536,19 +593,6 @@ void Compton::test() {
     std::cout << "Optical depth: " << tau << " Compton-Y: " << ypar << " r: " << r << " z: " << z
               << " angle: " << angle << " speed: " << beta << " delta: " << dopfac << std::endl;
     std::cout << "Number of scatters: " << Niter << std::endl;
-}
-
-std::vector<double> Compton::get_seed_energ(){
-    return seed_energ;
-}
-std::vector<double> Compton::get_seed_urad(){
-    std::vector<double> vals(seed_urad.size(), 0.);
-    for (size_t i = 0; i < seed_urad.size(); i++)
-    {
-        vals[i] = std::pow(10., seed_urad[i]);
-    }
-    
-    return vals;
 }
 
 }    // namespace kariba

--- a/src/Compton.cpp
+++ b/src/Compton.cpp
@@ -372,14 +372,14 @@ void Compton::add_target_number_density_on_freq_grid(
 //! automatically added to the existing one. note: the second condition has a <=
 //! sign to dodge numerical errors when the seed field energy density is
 //! extremely low, which can result in negative values/nan for the target_diff_spec
-void Compton::cyclosyn_seed(const std::vector<double>& syn_frequencies,
+void Compton::cyclosyn_seed(const std::vector<double>& syn_energies,
                             const std::vector<double>& syn_number_rates) {
-    set_target_frequency_array(syn_frequencies);
+    set_target_energy_array(syn_energies);
 
     std::vector<double> new_target_diff_spec(syn_number_rates.size());
     for (size_t i = 0; i < syn_number_rates.size(); ++i) {
         new_target_diff_spec[i] = syn_number_rates[i] / (
-            syn_frequencies[i] * constants::herg *constants::cee * constants::pi * r * r);
+            syn_energies[i] * constants::herg *constants::cee * constants::pi * r * r);
     }
     add_target_diff_spec(new_target_diff_spec);
 }
@@ -392,7 +392,7 @@ void Compton::bb_seed_k(double Urad, double Tbb) {
     double ulim, energy;
     std::vector<double> bb_diff_spec(target_energy.size(), 1e-100);
 
-    ulim = log(3e2 * Tbb * constants::kboltz);
+    ulim = 3e2 * Tbb * constants::kboltz;
     
     for (size_t i = 0; i < target_energy.size(); i++) {
         if (target_energy[i] < ulim) {

--- a/src/Compton.cpp
+++ b/src/Compton.cpp
@@ -228,8 +228,13 @@ void Compton::compton_spectrum(double gmin, double gmax, gsl_spline* eldis,
             if (com == 0) {
                 iter_urad[i] = -50;
             } else {
-                iter_urad[i] = std::log10(escape_corr * com * vol /
+                if (geometry == "cylinder"){
+                    iter_urad[i] = std::log10(escape_corr * com * vol /
+                                          (constants::pi * r * z * constants::cee));
+                } else {
+                    iter_urad[i] = std::log10(escape_corr * com * vol /
                                           (constants::pi * std::pow(r, 2.) * constants::cee));
+                }
             }
         }
         ephmin = en_phot.front();    // [0];

--- a/src/Compton.cpp
+++ b/src/Compton.cpp
@@ -72,8 +72,8 @@ Compton::~Compton() {
 }
 
 Compton::Compton(size_t size, size_t target_size)
-    : Radiation(size), target_energy(target_size, 0.0), log_target_diff_spec(target_size, 0.0), 
-      log_target_diff_spec_iter(size, 0.0) {
+    : Radiation(size), target_energy(target_size, 0.0), log_target_diff_spec(target_size, -230), 
+      log_target_diff_spec_iter(size, -230) {
     en_phot_obs.resize(en_phot_obs.size() * 2, 0.0);
     num_phot_obs.resize(num_phot_obs.size() * 2, 0.0);
 
@@ -232,7 +232,7 @@ void Compton::compton_spectrum(double gmin, double gmax, gsl_spline* eldis,
                 num_phot_obs[i + size] = 0.0;
             }
             if (com == 0) {
-                log_target_diff_spec_iter[i] = -50;
+                log_target_diff_spec_iter[i] = -230;
             } else {
                 if (geometry == "cylinder"){
                     log_target_diff_spec_iter[i] = log(escape_corr * com * vol /
@@ -252,7 +252,7 @@ void Compton::compton_spectrum(double gmin, double gmax, gsl_spline* eldis,
 //! Method to set new target energy array, resets also log_target_diff_spec
 void Compton::set_target_energy_array(const std::vector<double>& new_target_energy) {
     target_energy = new_target_energy;
-    log_target_diff_spec = std::vector<double>(new_target_energy.size(), -100);
+    log_target_diff_spec = std::vector<double>(new_target_energy.size(), -230);
     gsl_spline_free(seed_ph);
     seed_ph = gsl_spline_alloc(gsl_interp_steffen, target_energy.size());
 }
@@ -262,7 +262,7 @@ void Compton::set_target_frequency_array(const std::vector<double>& new_target_f
     for (size_t i = 0; i < new_target_frequency.size(); i++) {
         target_energy[i] = new_target_frequency[i] * constants::herg;
     }
-    log_target_diff_spec = std::vector<double>(new_target_frequency.size(), -100);
+    log_target_diff_spec = std::vector<double>(new_target_frequency.size(), -230);
     gsl_spline_free(seed_ph);
     seed_ph = gsl_spline_alloc(gsl_interp_steffen, target_energy.size());
 }
@@ -576,7 +576,7 @@ std::vector<double> Compton::get_target_diff_spec(){
 //! This resets the energy density in case different photon fields want to be
 //! calculated separately to see the contribution of each
 void Compton::reset() {
-    std::fill(log_target_diff_spec.begin(), log_target_diff_spec.end(), 0);
+    std::fill(log_target_diff_spec.begin(), log_target_diff_spec.end(), -230);
     std::fill(target_energy.begin(), target_energy.end(), 0);
     std::fill(num_phot.begin(), num_phot.end(), 0);
     std::fill(num_phot_obs.begin(), num_phot_obs.end(), 0);

--- a/src/Compton.cpp
+++ b/src/Compton.cpp
@@ -446,7 +446,7 @@ double disk_integral(double alfa, void* pars) {
 }
 
 void Compton::shsdisk_seed(double tin, double rin, double rout, double h, double z) {
-    double ulim, blim, logElim, Gamma, result, error;
+    double ulim, blim, Elim, Gamma, result, error;
     std::vector<double> disk_diff_spec(target_energy.size(), 1e-100);
 
     Gamma = 1. / pow((1. - pow(beta, 2.)), 1. / 2.);

--- a/src/Compton.cpp
+++ b/src/Compton.cpp
@@ -325,7 +325,7 @@ void Compton::add_target_energy_density(
     const double x_min = log_new_target_energy.front();
     const double x_max = log_new_target_energy.back();
 
-    std::vector<double> interp_log_new_target_diff_spec(log_target_energy.size());
+    std::vector<double> interp_new_target_diff_spec(log_target_energy.size());
     for (size_t i = 0; i < log_target_energy.size(); ++i) {
         const double x = log_target_energy[i];
 
@@ -335,7 +335,7 @@ void Compton::add_target_energy_density(
         }
 
         // Interpolate log(E-density_new) at this log(E)
-        interp_new_target_diff_spec[i] = std:exp(gsl_spline_eval(spline_add_target, x, acc_add_target));
+        interp_new_target_diff_spec[i] = exp(gsl_spline_eval(spline_add_target, x, acc_add_target));
     }
 
     gsl_spline_free(spline_add_target);

--- a/src/Compton.cpp
+++ b/src/Compton.cpp
@@ -147,6 +147,7 @@ double comint(double gam, void* pars) {
     gsl_interp_accel* acc_eldis = (params->acc_eldis);
     gsl_spline* phodis = (params->phodis);
     gsl_interp_accel* acc_phodis = (params->acc_phodis);
+    gsl_integration_workspace* w2 = (params->w2);
 
     double game, econst, blim, ulim, e1, elden;
     double result, error;
@@ -178,8 +179,8 @@ double Compton::comintegral(size_t it, double blim, double ulim, double enphot, 
     double result, error;
 
     gsl_function F1;
-    auto F1params = ComintParams{enphot, enphmin, enphmax, eldis, acc_eldis, seed_ph, acc_seed};
-    auto F1params_it = ComintParams{enphot, enphmin, enphmax, eldis, acc_eldis, iter_ph, acc_iter};
+    auto F1params = ComintParams{enphot, enphmin, enphmax, eldis, acc_eldis, seed_ph, acc_seed, w2};
+    auto F1params_it = ComintParams{enphot, enphmin, enphmax, eldis, acc_eldis, iter_ph, acc_iter, w2};
     F1.function = &comint;
     if (it == 0) {
         F1.params = &F1params;

--- a/src/Compton.cpp
+++ b/src/Compton.cpp
@@ -206,8 +206,8 @@ void Compton::compton_spectrum(double gmin, double gmax, gsl_spline* eldis,
     double dopfac_cj;
     double ephmin, ephmax;
 
-    ephmin = pow(10., log_target_energy.front());    //[0];
-    ephmax = pow(10., log_target_energy.back());     //[target_size - 1];
+    ephmin = exp(log_target_energy.front());    //[0];
+    ephmax = exp(log_target_energy.back());     //[target_size - 1];
 
     dopfac_cj = dopfac * (1. - beta * cos(angle)) / (1. + beta * cos(angle));
 

--- a/src/Compton.cpp
+++ b/src/Compton.cpp
@@ -247,25 +247,29 @@ void Compton::compton_spectrum(double gmin, double gmax, gsl_spline* eldis,
 void Compton::cyclosyn_seed(const std::vector<double>& seed_arr,
                             const std::vector<double>& seed_lum) {
     // to do: asssert input and member sizes are the same
+    double new_val;
     for (size_t i = 0; i < seed_arr.size(); i++) {
         seed_energ[i] = seed_arr[i];
+        if (geometry == "cylinder") {
+            new_val = seed_lum[i] / (constants::cee * constants::herg *
+                                     seed_energ[i] * constants::pi * r * z);
+        }
+        else {
+            new_val = std::log10(seed_lum[i] / (constants::cee * constants::herg *
+                                                        seed_energ[i] * constants::pi * r * r));
+        }
         if (seed_urad[i] != 0) {
-            seed_urad[i] = std::log10(std::pow(10., seed_urad[i]) +
-                                      seed_lum[i] / (constants::cee * constants::herg *
-                                                     seed_energ[i] * constants::pi * r * r));
-        } else if (seed_lum[i] /
-                       (constants::cee * constants::herg * seed_energ[i] * constants::pi * r * r) <=
-                   0) {
+            seed_urad[i] = std::log10(std::pow(10., seed_urad[i]) + new_val);
+        } else if (new_val <= 0) {
             seed_urad[i] = -100;
         } else {
-            seed_urad[i] = std::log10(seed_lum[i] / (constants::cee * constants::herg *
-                                                     seed_energ[i] * constants::pi * r * r));
+            seed_urad[i] = std::log10(new_val);
         }
     }
     gsl_spline_init(seed_ph, seed_energ.data(), seed_urad.data(), seed_energ.size());
 }
 
-void Compton::add_seed(const std::vector<double>& seed_syn_energ, const std::vector<double>& seed_arr) {
+void Compton::add_seed(const std::vector<double>& seed_syn_energ, const std::vector<double>& seed_energy_density) {
     double emin, emax, urad;
 
     emin = seed_energ[0];
@@ -277,7 +281,7 @@ void Compton::add_seed(const std::vector<double>& seed_syn_energ, const std::vec
         if (seed_syn_energ[i] < emin) {
             urad = 1.e-100;
         } else if (seed_syn_energ[i] < emax) {
-            urad = seed_arr[i];
+            urad = seed_energy_density[i]/seed_syn_energ[i]/seed_syn_energ[i];
         } else {
             urad = 1.e-100;
         }

--- a/src/Compton.cpp
+++ b/src/Compton.cpp
@@ -509,4 +509,11 @@ void Compton::test() {
     std::cout << "Number of scatters: " << Niter << std::endl;
 }
 
+std::vector<double> Compton::get_seed_energ(){
+    return seed_energ;
+}
+std::vector<double> Compton::get_seed_urad(){
+    return std::pow(10., seed_urad);
+}
+
 }    // namespace kariba

--- a/src/Compton.cpp
+++ b/src/Compton.cpp
@@ -128,7 +128,17 @@ double comfnc(double logein, void* pars) {
     } else {
         biggam = eg4 / constants::emerg;
         q = e1 / (biggam * (1. - e1));
-        phonum = exp(gsl_spline_eval(phodis, logein, acc_phodis));
+        // phonum = exp(gsl_spline_eval(phodis, logein, acc_phodis));
+        double y;
+        int status = gsl_spline_eval_e(phodis, logein, acc_phodis, &y);
+        if (status != 0) {
+            std::cerr << "comfnc: gsl_spline_eval_e error " << status
+                    << " at logein=" << logein
+                    << " (E=" << std::exp(logein) << " erg)" << std::endl;
+            // You can also print the domain here if you track it in params.
+            return 0.0;
+        }
+        phonum = std::exp(y);
         tm1 = 2. * q * log(q);
         tm2 = (1. + 2. * q) * (1. - q);
         tm3 = 0.5 * (pow(biggam * q, 2.) * (1. - q)) / (1. + biggam * q);
@@ -157,6 +167,13 @@ double comint(double gam, void* pars) {
     econst = 2. * constants::pi * constants::re0 * constants::re0 * constants::cee;
     blim = log(std::max(eph / (4. * game * (game - eph / constants::emerg)), ephmin));
     ulim = log(std::min(eph, ephmax));
+
+    double xmin = gsl_spline_min(phodis);  // log(E_min) for this spline
+    double xmax = gsl_spline_max(phodis);  // log(E_max)
+
+    // Clamp integration range to spline domain
+    blim = std::max(blim, xmin);
+    ulim = std::min(ulim, xmax);
 
     if (ulim <= blim) {
         return 0;

--- a/src/Compton.cpp
+++ b/src/Compton.cpp
@@ -312,7 +312,7 @@ void Compton::add_target_energy_density(
     std::vector<double> log_new_target_diff_spec(new_target_energy_density.size());
     for (size_t i = 0; i < new_target_energy.size(); ++i) {
         log_new_target_energy[i] = log(new_target_energy[i]);
-        log_new_target_diff_spec[i] = log(new_target_energy_density[i] / pow(new_target_energy, 2.));
+        log_new_target_diff_spec[i] = log(new_target_energy_density[i] / pow(new_target_energy[i], 2.));
     }
 
     // x = log(E), y = log(E-density)

--- a/src/Compton.cpp
+++ b/src/Compton.cpp
@@ -593,7 +593,9 @@ void Compton::reset() {
 
 void Compton::urad_test() {
     for (size_t i = 0; i < log_target_energy.size(); i++) {
-        std::cout << exp(log_target_energy[i]) / constants::herg << " " << exp(log_target_diff_spec[i]) << " " << exp(log_target_diff_spec_iter)[i]
+        std::cout << exp(log_target_energy[i]) / constants::herg 
+                  << " " << exp(log_target_diff_spec[i]) << " " 
+                  << exp(log_target_diff_spec_iter[i])
                   << std::endl;
     }
 }

--- a/src/Compton.cpp
+++ b/src/Compton.cpp
@@ -72,11 +72,10 @@ Compton::~Compton() {
 }
 
 Compton::Compton(size_t size, size_t target_size)
-    : Radiation(size), log_target_energy(target_size, 0.0), log_target_diff_spec(target_size, 0.0), 
+    : Radiation(size), target_energy(target_size, 0.0), log_target_diff_spec(target_size, 0.0), 
       log_target_diff_spec_iter(size, 0.0) {
     en_phot_obs.resize(en_phot_obs.size() * 2, 0.0);
     num_phot_obs.resize(num_phot_obs.size() * 2, 0.0);
-    log_energy_iter.resize(en_phot.size(), -100.);
 
     Niter = 20;
     ypar = 0;
@@ -128,7 +127,7 @@ double comfnc(double logein, void* pars) {
     } else {
         biggam = eg4 / constants::emerg;
         q = e1 / (biggam * (1. - e1));
-        phonum = exp(gsl_spline_eval(phodis, logein, acc_phodis));
+        phonum = exp(gsl_spline_eval(phodis, einit, acc_phodis));
         tm1 = 2. * q * log(q);
         tm2 = (1. + 2. * q) * (1. - q);
         tm3 = 0.5 * (pow(biggam * q, 2.) * (1. - q)) / (1. + biggam * q);
@@ -141,8 +140,8 @@ double comfnc(double logein, void* pars) {
 double comint(double gam, void* pars) {
     ComintParams* params = static_cast<ComintParams*>(pars);
     double eph = (params->eph);
-    double logephmin = (params->ephmin);
-    double logephmax = (params->ephmax);
+    double ephmin = (params->ephmin);
+    double ephmax = (params->ephmax);
     gsl_spline* eldis = (params->eldis);
     gsl_interp_accel* acc_eldis = (params->acc_eldis);
     gsl_spline* phodis = (params->phodis);
@@ -155,8 +154,8 @@ double comint(double gam, void* pars) {
     game = exp(gam);
     e1 = eph / (game * constants::emerg);
     econst = 2. * constants::pi * constants::re0 * constants::re0 * constants::cee;
-    blim = std::max(log(eph / (4. * game * (game - eph / constants::emerg))), logephmin);
-    ulim = std::min(log(eph), logephmax);
+    blim = log(std::max(eph / (4. * game * (game - eph / constants::emerg)), ephmin));
+    ulim = log(std::min(eph, ephmax));
 
     if (ulim <= blim) {
         return 0;
@@ -174,13 +173,13 @@ double comint(double gam, void* pars) {
 
 //! This integrates the individual electron spectrum from comint over the total
 //! electron distribution
-double Compton::comintegral(size_t it, double blim, double ulim, double enphot, double logenphmin,
-                            double logenphmax, gsl_spline* eldis, gsl_interp_accel* acc_eldis) {
+double Compton::comintegral(size_t it, double blim, double ulim, double enphot, double enphmin,
+                            double enphmax, gsl_spline* eldis, gsl_interp_accel* acc_eldis) {
     double result, error;
 
     gsl_function F1;
-    auto F1params = ComintParams{enphot, logenphmin, logenphmax, eldis, acc_eldis, seed_ph, acc_seed, w2};
-    auto F1params_it = ComintParams{enphot, logenphmin, logenphmax, eldis, acc_eldis, iter_ph, acc_iter, w2};
+    auto F1params = ComintParams{enphot, enphmin, enphmax, eldis, acc_eldis, seed_ph, acc_seed, w2};
+    auto F1params_it = ComintParams{enphot, enphmin, enphmax, eldis, acc_eldis, iter_ph, acc_iter, w2};
     F1.function = &comint;
     if (it == 0) {
         F1.params = &F1params;
@@ -204,28 +203,23 @@ void Compton::compton_spectrum(double gmin, double gmax, gsl_spline* eldis,
                                gsl_interp_accel* acc_eldis) {
     double blim, ulim, com;
     double dopfac_cj;
-    double logephmin, logephmax;
+    double ephmin, ephmax;
 
-    logephmin = log_target_energy.front();    //[0];
-    logephmax = log_target_energy.back();     //[target_size - 1];
+    ephmin = target_energy.front();    //[0];
+    ephmax = target_energy.back();     //[target_size - 1];
 
     dopfac_cj = dopfac * (1. - beta * cos(angle)) / (1. + beta * cos(angle));
 
     size_t size = en_phot.size();
     for (size_t it = 0; it < Niter; it++) {
         for (size_t i = 0; i < size; i++) {
-            if (it==0) {
-                log_energy_iter[i] = log(en_phot[i]);
-            } else {
-                logephmin = log_energy_iter.front();    //[0];
-                logephmax = log_energy_iter.back();
-            }
+    
             blim = log(std::max(gmin, en_phot[i] / constants::emerg));
             ulim = log(gmax);
             if (blim >= ulim) {
                 com = 1e-100;
             } else {
-                com = comintegral(it, blim, ulim, en_phot[i], logephmin, logephmax, eldis, acc_eldis);
+                com = comintegral(it, blim, ulim, en_phot[i], ephmin, ephmax, eldis, acc_eldis);
             }
             num_phot[i] = num_phot[i] + com * vol * en_phot[i] * constants::herg;
             en_phot_obs[i] = en_phot[i] * dopfac;
@@ -249,27 +243,24 @@ void Compton::compton_spectrum(double gmin, double gmax, gsl_spline* eldis,
                 }
             }
         }
-        // ephmin = en_phot.front();    // [0];
-        // ephmax = en_phot.back();     //[size - 1];
-        gsl_spline_init(iter_ph, log_energy_iter.data(), log_target_diff_spec_iter.data(), size);
+        ephmin = en_phot.front();    // [0];
+        ephmax = en_phot.back();     //[size - 1];
+        gsl_spline_init(iter_ph, en_phot.data(), log_target_diff_spec_iter.data(), size);
     }
 }
 
 //! Method to set new target energy array, resets also log_target_diff_spec
 void Compton::set_target_energy_array(const std::vector<double>& new_target_energy) {
-    log_target_energy = std::vector<double>(new_target_energy.size());
-    for (size_t i = 0; i < new_target_energy.size(); i++) {
-        log_target_energy[i] = log(new_target_energy[i]);
-    }
+    target_energy = new_target_energy;
     log_target_diff_spec = std::vector<double>(new_target_energy.size(), -100);
     gsl_spline_free(seed_ph);
     seed_ph = gsl_spline_alloc(gsl_interp_steffen, log_target_energy.size());
 }
 //! Method to set target energy array from frequency array, resets also log_target_diff_spec
 void Compton::set_target_frequency_array(const std::vector<double>& new_target_frequency) {
-    log_target_energy = std::vector<double>(new_target_frequency.size());
+    target_energy = std::vector<double>(new_target_frequency.size());
     for (size_t i = 0; i < new_target_frequency.size(); i++) {
-        log_target_energy[i] = log(new_target_frequency[i] * constants::herg);
+        target_energy[i] = new_target_frequency[i] * constants::herg;
     }
     log_target_diff_spec = std::vector<double>(new_target_frequency.size(), -100);
     gsl_spline_free(seed_ph);
@@ -292,7 +283,7 @@ void Compton::add_target_diff_spec(
         }
     }
     
-    gsl_spline_init(seed_ph, log_target_energy.data(), log_target_diff_spec.data(), log_target_energy.size());
+    gsl_spline_init(seed_ph, target_energy.data(), log_target_diff_spec.data(), log_target_energy.size());
 }
 
 // adds target, cuts off outside energy boundaries, interpolates inbetween
@@ -331,8 +322,8 @@ void Compton::add_target_energy_density(
     const double x_max = log_new_target_energy.back();
 
     std::vector<double> interp_new_target_diff_spec(log_target_energy.size());
-    for (size_t i = 0; i < log_target_energy.size(); ++i) {
-        const double x = log_target_energy[i];
+    for (size_t i = 0; i < target_energy.size(); ++i) {
+        const double x = log(target_energy[i]);
 
         // If outside new grid → contribution is zero, so do nothing.
         if (x < x_min || x > x_max) {
@@ -399,13 +390,13 @@ void Compton::cyclosyn_seed(const std::vector<double>& syn_frequencies,
 //! does NOT account for beaming
 void Compton::bb_seed_k(double Urad, double Tbb) {
     double ulim, energy;
-    std::vector<double> bb_diff_spec(log_target_energy.size(), 1e-100);
+    std::vector<double> bb_diff_spec(target_energy.size(), 1e-100);
 
     ulim = log(3e2 * Tbb * constants::kboltz);
     
-    for (size_t i = 0; i < log_target_energy.size(); i++) {
-        if (log_target_energy[i] < ulim) {
-            energy = exp(log_target_energy[i]);
+    for (size_t i = 0; i < target_energy.size(); i++) {
+        if (target_energy[i] < ulim) {
+            energy = target_energy[i];
             bb_diff_spec[i] = (2. * Urad * pow(energy / constants::herg, 2.)) /
                       (constants::herg * pow(constants::cee, 2.) * constants::sbconst *
                        pow(Tbb, 4) * (exp(energy / (constants::kboltz * Tbb)) - 1.));
@@ -456,7 +447,7 @@ double disk_integral(double alfa, void* pars) {
 
 void Compton::shsdisk_seed(double tin, double rin, double rout, double h, double z) {
     double ulim, blim, logElim, Gamma, result, error;
-    std::vector<double> disk_diff_spec(log_target_energy.size(), 1e-100);
+    std::vector<double> disk_diff_spec(target_energy.size(), 1e-100);
 
     Gamma = 1. / pow((1. - pow(beta, 2.)), 1. / 2.);
 
@@ -466,13 +457,13 @@ void Compton::shsdisk_seed(double tin, double rin, double rout, double h, double
     } else {
         ulim = atan(rout / (z - h * rout / 2.));
     }
-    logElim = log(1e1 * tin * constants::kboltz);
+    Elim = 1e1 * tin * constants::kboltz;
 
-    for (size_t i = 0; i < log_target_energy.size(); i++) {
-        if (log_target_energy[i] < logElim) {
+    for (size_t i = 0; i < target_energy.size(); i++) {
+        if (target_energy[i] < Elim) {
             gsl_function F;
             auto Fparams =
-                DiskIcParams{Gamma, beta, tin, rin, rout, h, z, exp(log_target_energy[i]) / constants::herg};
+                DiskIcParams{Gamma, beta, tin, rin, rout, h, z, target_energy[i] / constants::herg};
             F.function = &disk_integral;
             F.params = &Fparams;
             gsl_integration_qag(&F, blim, ulim, 0, 1e-5, 100, 2, w1, &result, &error);
@@ -568,13 +559,7 @@ void Compton::set_escape(double escape) { escape_corr = escape; }
 
 
 std::vector<double> Compton::get_target_energy(){
-    std::vector<double> vals(log_target_energy.size(), 0.);
-    for (size_t i = 0; i < log_target_energy.size(); i++)
-    {
-        vals[i] = exp(log_target_energy[i]);
-    }
-    
-    return vals;
+    return target_energy;
 }
 
 std::vector<double> Compton::get_target_diff_spec(){
@@ -592,14 +577,14 @@ std::vector<double> Compton::get_target_diff_spec(){
 //! calculated separately to see the contribution of each
 void Compton::reset() {
     std::fill(log_target_diff_spec.begin(), log_target_diff_spec.end(), 0);
-    std::fill(log_target_energy.begin(), log_target_energy.end(), 0);
+    std::fill(target_energy.begin(), target_energy.end(), 0);
     std::fill(num_phot.begin(), num_phot.end(), 0);
     std::fill(num_phot_obs.begin(), num_phot_obs.end(), 0);
 }
 
 void Compton::urad_test() {
-    for (size_t i = 0; i < log_target_energy.size(); i++) {
-        std::cout << exp(log_target_energy[i]) / constants::herg 
+    for (size_t i = 0; i < target_energy.size(); i++) {
+        std::cout << target_energy[i] / constants::herg 
                   << " " << exp(log_target_diff_spec[i]) << " " 
                   << exp(log_target_diff_spec_iter[i])
                   << std::endl;

--- a/src/Compton.cpp
+++ b/src/Compton.cpp
@@ -91,7 +91,7 @@ Compton::Compton(size_t size, size_t target_size)
     gsl_spline2d_init(esc_p_sph, Te_table, tau_table, esc_table_sph, 15, 15);
     gsl_spline2d_init(esc_p_cyl, Te_table, tau_table, esc_table_cyl, 15, 15);
 
-    seed_ph = gsl_spline_alloc(gsl_interp_steffen, log_target_energy.size());
+    seed_ph = gsl_spline_alloc(gsl_interp_steffen, target_energy.size());
     acc_seed = gsl_interp_accel_alloc();
 
     iter_ph = gsl_spline_alloc(gsl_interp_steffen, en_phot.size());
@@ -254,7 +254,7 @@ void Compton::set_target_energy_array(const std::vector<double>& new_target_ener
     target_energy = new_target_energy;
     log_target_diff_spec = std::vector<double>(new_target_energy.size(), -100);
     gsl_spline_free(seed_ph);
-    seed_ph = gsl_spline_alloc(gsl_interp_steffen, log_target_energy.size());
+    seed_ph = gsl_spline_alloc(gsl_interp_steffen, target_energy.size());
 }
 //! Method to set target energy array from frequency array, resets also log_target_diff_spec
 void Compton::set_target_frequency_array(const std::vector<double>& new_target_frequency) {
@@ -264,7 +264,7 @@ void Compton::set_target_frequency_array(const std::vector<double>& new_target_f
     }
     log_target_diff_spec = std::vector<double>(new_target_frequency.size(), -100);
     gsl_spline_free(seed_ph);
-    seed_ph = gsl_spline_alloc(gsl_interp_steffen, log_target_energy.size());
+    seed_ph = gsl_spline_alloc(gsl_interp_steffen, target_energy.size());
 }
 
 // adds target and updates spline, assumes ame energy grid
@@ -283,7 +283,7 @@ void Compton::add_target_diff_spec(
         }
     }
     
-    gsl_spline_init(seed_ph, target_energy.data(), log_target_diff_spec.data(), log_target_energy.size());
+    gsl_spline_init(seed_ph, target_energy.data(), log_target_diff_spec.data(), target_energy.size());
 }
 
 // adds target, cuts off outside energy boundaries, interpolates inbetween
@@ -321,7 +321,7 @@ void Compton::add_target_energy_density(
     const double x_min = log_new_target_energy.front();
     const double x_max = log_new_target_energy.back();
 
-    std::vector<double> interp_new_target_diff_spec(log_target_energy.size());
+    std::vector<double> interp_new_target_diff_spec(target_energy.size());
     for (size_t i = 0; i < target_energy.size(); ++i) {
         const double x = log(target_energy[i]);
 

--- a/src/Compton.cpp
+++ b/src/Compton.cpp
@@ -255,14 +255,8 @@ void Compton::cyclosyn_seed(const std::vector<double>& seed_arr,
     double new_val;
     for (size_t i = 0; i < seed_arr.size(); i++) {
         seed_energ[i] = seed_arr[i];
-        if (geometry == "cylinder") {
-            new_val = seed_lum[i] / (constants::cee * constants::herg *
-                                     seed_energ[i] * constants::pi * r * r);
-        }
-        else {
-            new_val = std::log10(seed_lum[i] / (constants::cee * constants::herg *
-                                                        seed_energ[i] * constants::pi * r * r));
-        }
+        new_val = seed_lum[i] / (constants::cee * constants::herg *
+                                    seed_energ[i] * constants::pi * r * r);
         if (seed_urad[i] != 0) {
             seed_urad[i] = std::log10(std::pow(10., seed_urad[i]) + new_val);
         } else if (new_val <= 0) {

--- a/src/Compton.cpp
+++ b/src/Compton.cpp
@@ -466,7 +466,7 @@ void Compton::shsdisk_seed(double tin, double rin, double rout, double h, double
         if (log_target_energy[i] < logElim) {
             gsl_function F;
             auto Fparams =
-                DiskIcParams{Gamma, beta, tin, rin, rout, h, z, exp(log_target_energy[i] / constants::herg)};
+                DiskIcParams{Gamma, beta, tin, rin, rout, h, z, exp(log_target_energy[i]) / constants::herg};
             F.function = &disk_integral;
             F.params = &Fparams;
             gsl_integration_qag(&F, blim, ulim, 0, 1e-5, 100, 2, w1, &result, &error);

--- a/src/Compton.cpp
+++ b/src/Compton.cpp
@@ -168,13 +168,6 @@ double comint(double gam, void* pars) {
     blim = log(std::max(eph / (4. * game * (game - eph / constants::emerg)), ephmin));
     ulim = log(std::min(eph, ephmax));
 
-    double xmin = gsl_spline_min(phodis);  // log(E_min) for this spline
-    double xmax = gsl_spline_max(phodis);  // log(E_max)
-
-    // Clamp integration range to spline domain
-    blim = std::max(blim, xmin);
-    ulim = std::min(ulim, xmax);
-
     if (ulim <= blim) {
         return 0;
     } else {

--- a/src/Compton.cpp
+++ b/src/Compton.cpp
@@ -252,7 +252,7 @@ void Compton::cyclosyn_seed(const std::vector<double>& seed_arr,
         seed_energ[i] = seed_arr[i];
         if (geometry == "cylinder") {
             new_val = seed_lum[i] / (constants::cee * constants::herg *
-                                     seed_energ[i] * constants::pi * r * z);
+                                     seed_energ[i] * constants::pi * r * r);
         }
         else {
             new_val = std::log10(seed_lum[i] / (constants::cee * constants::herg *

--- a/src/Compton.cpp
+++ b/src/Compton.cpp
@@ -513,7 +513,13 @@ std::vector<double> Compton::get_seed_energ(){
     return seed_energ;
 }
 std::vector<double> Compton::get_seed_urad(){
-    return std::pow(10., seed_urad);
+    std::vector<double> vals(seed_urad.size(), 0.);
+    for (size_t i = 0; i < seed_urad.size(); i++)
+    {
+        vals[i] = std::pow(10., seed_urad[i]);
+    }
+    
+    return vals;
 }
 
 }    // namespace kariba

--- a/src/Compton.cpp
+++ b/src/Compton.cpp
@@ -128,17 +128,7 @@ double comfnc(double logein, void* pars) {
     } else {
         biggam = eg4 / constants::emerg;
         q = e1 / (biggam * (1. - e1));
-        // phonum = exp(gsl_spline_eval(phodis, logein, acc_phodis));
-        double y;
-        int status = gsl_spline_eval_e(phodis, logein, acc_phodis, &y);
-        if (status != 0) {
-            std::cerr << "comfnc: gsl_spline_eval_e error " << status
-                    << " at logein=" << logein
-                    << " (E=" << std::exp(logein) << " erg)" << std::endl;
-            // You can also print the domain here if you track it in params.
-            return 0.0;
-        }
-        phonum = std::exp(y);
+        phonum = exp(gsl_spline_eval(phodis, logein, acc_phodis));
         tm1 = 2. * q * log(q);
         tm2 = (1. + 2. * q) * (1. - q);
         tm3 = 0.5 * (pow(biggam * q, 2.) * (1. - q)) / (1. + biggam * q);
@@ -151,8 +141,8 @@ double comfnc(double logein, void* pars) {
 double comint(double gam, void* pars) {
     ComintParams* params = static_cast<ComintParams*>(pars);
     double eph = (params->eph);
-    double ephmin = (params->ephmin);
-    double ephmax = (params->ephmax);
+    double logephmin = (params->ephmin);
+    double logephmax = (params->ephmax);
     gsl_spline* eldis = (params->eldis);
     gsl_interp_accel* acc_eldis = (params->acc_eldis);
     gsl_spline* phodis = (params->phodis);
@@ -165,8 +155,8 @@ double comint(double gam, void* pars) {
     game = exp(gam);
     e1 = eph / (game * constants::emerg);
     econst = 2. * constants::pi * constants::re0 * constants::re0 * constants::cee;
-    blim = log(std::max(eph / (4. * game * (game - eph / constants::emerg)), ephmin));
-    ulim = log(std::min(eph, ephmax));
+    blim = std::max(log(eph / (4. * game * (game - eph / constants::emerg))), logephmin);
+    ulim = std::min(log(eph), logephmax);
 
     if (ulim <= blim) {
         return 0;
@@ -184,13 +174,13 @@ double comint(double gam, void* pars) {
 
 //! This integrates the individual electron spectrum from comint over the total
 //! electron distribution
-double Compton::comintegral(size_t it, double blim, double ulim, double enphot, double enphmin,
-                            double enphmax, gsl_spline* eldis, gsl_interp_accel* acc_eldis) {
+double Compton::comintegral(size_t it, double blim, double ulim, double enphot, double logenphmin,
+                            double logenphmax, gsl_spline* eldis, gsl_interp_accel* acc_eldis) {
     double result, error;
 
     gsl_function F1;
-    auto F1params = ComintParams{enphot, enphmin, enphmax, eldis, acc_eldis, seed_ph, acc_seed, w2};
-    auto F1params_it = ComintParams{enphot, enphmin, enphmax, eldis, acc_eldis, iter_ph, acc_iter, w2};
+    auto F1params = ComintParams{enphot, logenphmin, logenphmax, eldis, acc_eldis, seed_ph, acc_seed, w2};
+    auto F1params_it = ComintParams{enphot, logenphmin, logenphmax, eldis, acc_eldis, iter_ph, acc_iter, w2};
     F1.function = &comint;
     if (it == 0) {
         F1.params = &F1params;
@@ -214,23 +204,28 @@ void Compton::compton_spectrum(double gmin, double gmax, gsl_spline* eldis,
                                gsl_interp_accel* acc_eldis) {
     double blim, ulim, com;
     double dopfac_cj;
-    double ephmin, ephmax;
+    double logephmin, logephmax;
 
-    ephmin = exp(log_target_energy.front());    //[0];
-    ephmax = exp(log_target_energy.back());     //[target_size - 1];
+    logephmin = log_target_energy.front();    //[0];
+    logephmax = log_target_energy.back();     //[target_size - 1];
 
     dopfac_cj = dopfac * (1. - beta * cos(angle)) / (1. + beta * cos(angle));
 
     size_t size = en_phot.size();
     for (size_t it = 0; it < Niter; it++) {
         for (size_t i = 0; i < size; i++) {
-            if (it==0) log_energy_iter[i] = log(en_phot[i]);
+            if (it==0) {
+                log_energy_iter[i] = log(en_phot[i]);
+            } else {
+                logephmin = log_energy_iter.front();    //[0];
+                logephmax = log_energy_iter.back();
+            }
             blim = log(std::max(gmin, en_phot[i] / constants::emerg));
             ulim = log(gmax);
             if (blim >= ulim) {
                 com = 1e-100;
             } else {
-                com = comintegral(it, blim, ulim, en_phot[i], ephmin, ephmax, eldis, acc_eldis);
+                com = comintegral(it, blim, ulim, en_phot[i], logephmin, logephmax, eldis, acc_eldis);
             }
             num_phot[i] = num_phot[i] + com * vol * en_phot[i] * constants::herg;
             en_phot_obs[i] = en_phot[i] * dopfac;

--- a/src/Compton.cpp
+++ b/src/Compton.cpp
@@ -205,8 +205,8 @@ void Compton::compton_spectrum(double gmin, double gmax, gsl_spline* eldis,
     double dopfac_cj;
     double ephmin, ephmax;
 
-    ephmin = pow(10., lg_target_energy.front());    //[0];
-    ephmax = pow(10., lg_target_energy.back());     //[target_size - 1];
+    ephmin = pow(10., log_target_energy.front());    //[0];
+    ephmax = pow(10., log_target_energy.back());     //[target_size - 1];
 
     dopfac_cj = dopfac * (1. - beta * cos(angle)) / (1. + beta * cos(angle));
 
@@ -249,23 +249,25 @@ void Compton::compton_spectrum(double gmin, double gmax, gsl_spline* eldis,
     }
 }
 
-//! Method to set new target energy array, resets also lg_target_diff_spec
+//! Method to set new target energy array, resets also log_target_diff_spec
 void Compton::set_target_energy_array(const std::vector<double>& new_target_energy) {
-    lg_target_energy = log10(new_target_energy);
-    lg_target_diff_spec = std::vector<double>(new_target_energy.size(), -100);
-    gsl_spline_free(seed_ph);
-    seed_ph = gsl_spline_alloc(gsl_interp_steffen, lg_target_energy.size());
-}
-//! Method to set target energy array from frequency array, resets also lg_target_diff_spec
-void Compton::set_target_frequency_array(const std::vector<double>& new_target_frequency) {
-    lg_target_energy = std::vector<double>(new_target_frequency.size());
-    // to do: asssert input and member sizes are the same
-    for (size_t i = 0; i < new_target_frequency.size(); i++) {
-        lg_target_energy[i] = log10(new_target_frequency[i] * constants::herg);
+    log_target_energy = std::vector<double>(new_target_energy.size());
+    for (size_t i = 0; i < new_target_energy.size(); i++) {
+        log_target_energy[i] = log10(new_target_energy[i]);
     }
-    lg_target_diff_spec = std::vector<double>(new_target_frequency.size(), -100);
+    log_target_diff_spec = std::vector<double>(new_target_energy.size(), -100);
     gsl_spline_free(seed_ph);
-    seed_ph = gsl_spline_alloc(gsl_interp_steffen, lg_target_energy.size());
+    seed_ph = gsl_spline_alloc(gsl_interp_steffen, log_target_energy.size());
+}
+//! Method to set target energy array from frequency array, resets also log_target_diff_spec
+void Compton::set_target_frequency_array(const std::vector<double>& new_target_frequency) {
+    log_target_energy = std::vector<double>(new_target_frequency.size());
+    for (size_t i = 0; i < new_target_frequency.size(); i++) {
+        log_target_energy[i] = log10(new_target_frequency[i] * constants::herg);
+    }
+    log_target_diff_spec = std::vector<double>(new_target_frequency.size(), -100);
+    gsl_spline_free(seed_ph);
+    seed_ph = gsl_spline_alloc(gsl_interp_steffen, log_target_energy.size());
 }
 
 // adds target and updates spline, assumes ame energy grid
@@ -576,14 +578,14 @@ std::vector<double> Compton::get_target_diff_spec(){
 //! This resets the energy density in case different photon fields want to be
 //! calculated separately to see the contribution of each
 void Compton::reset() {
-    std::fill(lg_target_diff_spec.begin(), lg_target_diff_spec.end(), 0);
-    std::fill(lg_target_energy.begin(), lg_target_energy.end(), 0);
+    std::fill(log_target_diff_spec.begin(), log_target_diff_spec.end(), 0);
+    std::fill(log_target_energy.begin(), log_target_energy.end(), 0);
     std::fill(num_phot.begin(), num_phot.end(), 0);
     std::fill(num_phot_obs.begin(), num_phot_obs.end(), 0);
 }
 
 void Compton::urad_test() {
-    for (size_t i = 0; i < lg_target_energy.size(); i++) {
+    for (size_t i = 0; i < log_target_energy.size(); i++) {
         std::cout << exp(log_target_energy[i]) / constants::herg << " " << exp(log_target_diff_spec[i]) << " " << exp(log_target_diff_spec_iter)[i]
                   << std::endl;
     }

--- a/src/Compton.cpp
+++ b/src/Compton.cpp
@@ -377,12 +377,13 @@ void Compton::add_target_number_density_on_freq_grid(
 //! sign to dodge numerical errors when the seed field energy density is
 //! extremely low, which can result in negative values/nan for the target_diff_spec
 void Compton::cyclosyn_seed(const std::vector<double>& syn_frequencies,
-                            const std::vector<double>& syn_number_densities) {
+                            const std::vector<double>& syn_number_rates) {
     set_target_frequency_array(syn_frequencies);
 
-    std::vector<double> new_target_diff_spec(syn_number_densities.size());
-    for (size_t i = 0; i < syn_number_densities.size(); ++i) {
-        new_target_diff_spec[i] = syn_number_densities[i] / (syn_frequencies[i] * constants::herg);
+    std::vector<double> new_target_diff_spec(syn_number_rates.size());
+    for (size_t i = 0; i < syn_number_rates.size(); ++i) {
+        new_target_diff_spec[i] = syn_number_rates[i] / (
+            syn_frequencies[i] * constants::herg *constants::cee * constants::pi * r * r);
     }
     add_target_diff_spec(new_target_diff_spec);
 }

--- a/src/Compton.cpp
+++ b/src/Compton.cpp
@@ -562,7 +562,13 @@ void Compton::set_escape(double escape) { escape_corr = escape; }
 
 
 std::vector<double> Compton::get_target_energy(){
-    return exp(log_target_energy);
+    std::vector<double> vals(log_target_energy.size(), 0.);
+    for (size_t i = 0; i < log_target_energy.size(); i++)
+    {
+        vals[i] = exp(log_target_energy[i]);
+    }
+    
+    return vals;
 }
 
 std::vector<double> Compton::get_target_diff_spec(){

--- a/src/Compton.cpp
+++ b/src/Compton.cpp
@@ -249,8 +249,8 @@ void Compton::compton_spectrum(double gmin, double gmax, gsl_spline* eldis,
                 }
             }
         }
-        ephmin = en_phot.front();    // [0];
-        ephmax = en_phot.back();     //[size - 1];
+        // ephmin = en_phot.front();    // [0];
+        // ephmax = en_phot.back();     //[size - 1];
         gsl_spline_init(iter_ph, log_energy_iter.data(), log_target_diff_spec_iter.data(), size);
     }
 }

--- a/src/Cyclosyn.cpp
+++ b/src/Cyclosyn.cpp
@@ -31,7 +31,7 @@ Cyclosyn::~Cyclosyn() { gsl_spline_free(syn_f), gsl_interp_accel_free(syn_acc); 
 Cyclosyn::Cyclosyn(size_t size) : Radiation(size) {
     en_phot_obs.resize(en_phot_obs.size() * 2, 0.0);
     num_phot_obs.resize(num_phot_obs.size() * 2, 0.0);
-    cyclosyn_abs.resize(size, 0.0);
+    cyclosyn_absorption_rate.resize(size, 0.0);
 
     counterjet = false;
 
@@ -180,7 +180,7 @@ void Cyclosyn::cycsyn_spectrum(double gmin, double gmax, gsl_spline* eldis,
             acons = -constants::cee * constants::cee /
                     (8. * constants::pi * std::pow(en_phot[k] / constants::herg, 2.));
             asyn = acons * elcons * abs;
-            cyclosyn_abs[k] = asyn * constants::cee;
+            cyclosyn_absorption_rate[k] = asyn * constants::cee;
             epsasyn = emis / (acons * abs);
             if (geometry == "cylinder") {
                 tsyn = constants::pi / 2. * asyn * r;

--- a/src/Cyclosyn.cpp
+++ b/src/Cyclosyn.cpp
@@ -31,6 +31,7 @@ Cyclosyn::~Cyclosyn() { gsl_spline_free(syn_f), gsl_interp_accel_free(syn_acc); 
 Cyclosyn::Cyclosyn(size_t size) : Radiation(size) {
     en_phot_obs.resize(en_phot_obs.size() * 2, 0.0);
     num_phot_obs.resize(num_phot_obs.size() * 2, 0.0);
+    cyclosyn_abs.resize(size, 0.0);
 
     counterjet = false;
 
@@ -179,6 +180,7 @@ void Cyclosyn::cycsyn_spectrum(double gmin, double gmax, gsl_spline* eldis,
             acons = -constants::cee * constants::cee /
                     (8. * constants::pi * std::pow(en_phot[k] / constants::herg, 2.));
             asyn = acons * elcons * abs;
+            cyclosyn_abs[k] = asyn;
             epsasyn = emis / (acons * abs);
             if (geometry == "cylinder") {
                 tsyn = constants::pi / 2. * asyn * r;

--- a/src/Cyclosyn.cpp
+++ b/src/Cyclosyn.cpp
@@ -180,7 +180,7 @@ void Cyclosyn::cycsyn_spectrum(double gmin, double gmax, gsl_spline* eldis,
             acons = -constants::cee * constants::cee /
                     (8. * constants::pi * std::pow(en_phot[k] / constants::herg, 2.));
             asyn = acons * elcons * abs;
-            cyclosyn_absorption_rate[k] = asyn * constants::cee;
+            cyclosyn_absorption_rate[k] = asyn * constants::cee * constants::pi;
             epsasyn = emis / (acons * abs);
             if (geometry == "cylinder") {
                 tsyn = constants::pi / 2. * asyn * r;

--- a/src/Cyclosyn.cpp
+++ b/src/Cyclosyn.cpp
@@ -180,7 +180,7 @@ void Cyclosyn::cycsyn_spectrum(double gmin, double gmax, gsl_spline* eldis,
             acons = -constants::cee * constants::cee /
                     (8. * constants::pi * std::pow(en_phot[k] / constants::herg, 2.));
             asyn = acons * elcons * abs;
-            cyclosyn_abs[k] = asyn;
+            cyclosyn_abs[k] = asyn * constants::cee;
             epsasyn = emis / (acons * abs);
             if (geometry == "cylinder") {
                 tsyn = constants::pi / 2. * asyn * r;

--- a/src/Cyclosyn.cpp
+++ b/src/Cyclosyn.cpp
@@ -196,11 +196,8 @@ void Cyclosyn::cycsyn_spectrum(double gmin, double gmax, gsl_spline* eldis,
             } else {
                 tsyn_obs = constants::pi / 3. * asyn * r;
             }
-            if (tsyn_obs >= 1.) {
-                absfac_obs = (1. - std::exp(-tsyn_obs));
-            } else {
-                absfac_obs = tsyn_obs - std::pow(tsyn_obs, 2.) / 2. + std::pow(tsyn_obs, 3.) / 6.;
-            }
+            // numerically stable -( exp(-tsyn) - 1 )
+            absfac_obs = - std::expm1(-tsyn_obs);
 
             num_phot[k] = constants::pi * r * r * absfac * epsasyn;
             num_phot_obs[k] = 2. * r * z * absfac_obs * epsasyn * std::pow(dopfac, dopnum);

--- a/src/kariba/Compton.hpp
+++ b/src/kariba/Compton.hpp
@@ -14,12 +14,13 @@ class Compton : public Radiation {
     double rphot;          //!< photospheric radius when tau > 1, used to renormalize volume
     double escape_corr;    //!< escape term, used to renormalize our spectra to CompPS
 
-    std::vector<double> seed_energ;    //!< array of seed frequencies in Hz
-    std::vector<double> seed_urad;     //!< array of seed photon number density in log10(#/erg/cm^3)
+    std::vector<double> log_target_energy;    //!< array of seed energies in erg
+    std::vector<double> log_target_diff_spec;     //!< array of seed photon number density in log(#/erg/cm^3)
     std::vector<double>
-        iter_urad;    //!< array of iterated photon number density in log10(#/erg/cm^3)
+        log_target_diff_spec_iter;    //!< array of iterated photon number density in log(#/erg/cm^3)
+    std::vector<double> log_energy_iter;
 
-    gsl_spline* seed_ph;           //!< interpolation of photon field array seed_urad
+    gsl_spline* seed_ph;           //!< interpolation of photon field array target_diff_spec
     gsl_interp_accel* acc_seed;    //!< accelerator for above spline
 
     gsl_spline* iter_ph;           //!< interpolation of photon field for multiple scatters
@@ -32,41 +33,57 @@ class Compton : public Radiation {
     gsl_interp_accel* acc_tau;    //!< accelerator of above spline over tau
     gsl_interp_accel* acc_Te;     //!< accelerator of above spline over Te
 
+    gsl_integration_workspace* w1;
+    gsl_integration_workspace* w2;
+
   public:
     ~Compton();
-    Compton(size_t size, size_t seed_size);
+    Compton(size_t size, size_t target_size);
 
-    virtual double comintegral(size_t it, double blim, double ulim, double nu, double numin,
-                               double numax, gsl_spline* eldis, gsl_interp_accel* acc_eldis);
-    virtual void compton_spectrum(double gmin, double gmax, gsl_spline* eldis,
-                                  gsl_interp_accel* acc_eldis);
+    friend double comfnc(double logein, void* pars);
+    friend double comint(double gam, void* pars);
+    friend double disk_integral(double alfa, void* p);
+    virtual double comintegral(size_t it, double blim, double ulim, double nu, double numin, double numax,
+                       gsl_spline* eldis, gsl_interp_accel* acc_eldis);
+    virtual void compton_spectrum(double gmin, double gmax, gsl_spline* eldis, gsl_interp_accel* acc_eldis);
 
-    virtual void cyclosyn_seed(const std::vector<double>& seed_arr,
-                               const std::vector<double>& seed_lum);
-    void add_seed(const std::vector<double>& seed_syn_energ, const std::vector<double>& seed_arr);
-    virtual void bb_seed_k(const std::vector<double>& seed_arr, double Urad, double Tbb);
-    virtual void bb_seed_kev(const std::vector<double>& seed_energ, double Urad, double Tbb);
-    virtual void shsdisk_seed(const std::vector<double>& seed_arr, double tin, double rin,
-                              double rout, double h, double z);
+    virtual void set_target_energy_array(const std::vector<double>& new_target_energy);
+    virtual void set_target_frequency_array(const std::vector<double>& new_target_frequency);
 
-    virtual void set_frequency(double numin, double numax);
-    virtual void set_tau(double n, double gam);
-    virtual void set_tau(double _tau);
-    virtual void set_escape(double escape);
+    virtual void add_target_diff_spec(const std::vector<double>& new_target_diff_spec);
+    virtual void add_target_energy_density(
+      const std::vector<double>& new_target_energy,
+      const std::vector<double>& new_target_energy_density
+    );
+    virtual void add_target_number_density(
+      const std::vector<double>& new_target_energy,
+      const std::vector<double>& new_target_number_density
+    );
+    virtual void add_target_number_density_on_freq_grid(
+      const std::vector<double>& new_target_frequency,
+      const std::vector<double>& new_target_number_density
+    );
+
+    
+    virtual void cyclosyn_seed(const std::vector<double>& syn_frequencies, const std::vector<double>& syn_number_densities);
+    virtual void bb_seed_k(double Urad, double Tbb);
+    virtual void bb_seed_kev(double Urad, double Tbb);
+    virtual void shsdisk_seed(double tin, double rin, double rout,
+                      double h, double z);
+
     virtual void set_niter(double nu0, double Te);
     virtual void set_niter(size_t n);
-    virtual void seed_freq_array(const std::vector<double>& seed_energ);
+    virtual void set_tau(double n, double gam);
+    virtual void set_tau(double _tau);
+    virtual void set_frequency(double numin, double numax);
+    virtual void set_escape(double escape);
+
+    virtual std::vector<double> get_target_energy();
+    virtual std::vector<double> get_target_diff_spec();
 
     virtual double get_tau() const { return tau; };
 
     virtual double get_ypar() const { return ypar; };
-
-    virtual void reset();
-    virtual void urad_test();
-    virtual void test();
-
-    std::vector<double> get_seed_energ();
-    std::vector<double> get_seed_urad();
 
     friend double comfnc(double ein, void* p);
     friend double comint(double gam, void* p);

--- a/src/kariba/Compton.hpp
+++ b/src/kariba/Compton.hpp
@@ -64,6 +64,9 @@ class Compton : public Radiation {
     virtual void urad_test();
     virtual void test();
 
+    std::vector<double> get_seed_energ();
+    std::vector<double> get_seed_urad();
+
     friend double comfnc(double ein, void* p);
     friend double comint(double gam, void* p);
     friend double disk_integral(double alfa, void* p);

--- a/src/kariba/Compton.hpp
+++ b/src/kariba/Compton.hpp
@@ -9,7 +9,7 @@ namespace kariba {
 //! Class inverse Compton, inherited from Radiation.hpp
 class Compton : public Radiation {
   protected:
-    double log_floor = -230;
+    double log_floor = -230; // about 1e-100 
     size_t Niter;          //!< number of IC iterations
     double tau, ypar;      //!< optical depth/comtpon Y of emitting region
     double rphot;          //!< photospheric radius when tau > 1, used to renormalize volume

--- a/src/kariba/Compton.hpp
+++ b/src/kariba/Compton.hpp
@@ -43,34 +43,40 @@ class Compton : public Radiation {
     friend double comfnc(double logein, void* pars);
     friend double comint(double gam, void* pars);
     friend double disk_integral(double alfa, void* p);
-    virtual double comintegral(size_t it, double blim, double ulim, double nu, double numin, double numax,
-                       gsl_spline* eldis, gsl_interp_accel* acc_eldis);
-    virtual void compton_spectrum(double gmin, double gmax, gsl_spline* eldis, gsl_interp_accel* acc_eldis);
 
+    virtual double comintegral(size_t it, double blim, double ulim, double nu, double numin,
+                               double numax, gsl_spline* eldis, gsl_interp_accel* acc_eldis);
+    virtual void compton_spectrum(double gmin, double gmax, gsl_spline* eldis,
+                                  gsl_interp_accel* acc_eldis);
+
+    virtual void set_target_energy_array(const std::vector<double>& new_target_energy);
+    virtual void set_target_frequency_array(const std::vector<double>& new_target_frequency);
     virtual void set_target_energy_array(const std::vector<double>& new_target_energy);
     virtual void set_target_frequency_array(const std::vector<double>& new_target_frequency);
 
     virtual void add_target_diff_spec(const std::vector<double>& new_target_diff_spec);
     virtual void add_target_energy_density(
-      const std::vector<double>& new_target_energy,
-      const std::vector<double>& new_target_energy_density
-    );
+        const std::vector<double>& new_target_energy,
+        const std::vector<double>& new_target_energy_density);
     virtual void add_target_number_density(
-      const std::vector<double>& new_target_energy,
-      const std::vector<double>& new_target_number_density
-    );
+        const std::vector<double>& new_target_energy,
+        const std::vector<double>& new_target_number_density);
     virtual void add_target_number_density_on_freq_grid(
-      const std::vector<double>& new_target_frequency,
-      const std::vector<double>& new_target_number_density
-    );
+        const std::vector<double>& new_target_frequency,
+        const std::vector<double>& new_target_number_density);
 
-    
-    virtual void cyclosyn_seed(const std::vector<double>& syn_frequencies, const std::vector<double>& syn_number_densities);
+    virtual void cyclosyn_seed(const std::vector<double>& syn_energies,
+                               const std::vector<double>& syn_number_rates);
     virtual void bb_seed_k(double Urad, double Tbb);
     virtual void bb_seed_kev(double Urad, double Tbb);
-    virtual void shsdisk_seed(double tin, double rin, double rout,
-                      double h, double z);
+    virtual void shsdisk_seed(double tin, double rin, double rout, double h, double z);
 
+    virtual void set_niter(double nu0, double Te);
+    virtual void set_niter(size_t n);
+    virtual void set_tau(double n, double gam);
+    virtual void set_tau(double _tau);
+    virtual void set_frequency(double numin, double numax);
+    virtual void set_escape(double escape);
     virtual void set_niter(double nu0, double Te);
     virtual void set_niter(size_t n);
     virtual void set_tau(double n, double gam);
@@ -82,12 +88,46 @@ class Compton : public Radiation {
     virtual std::vector<double> get_target_diff_spec();
 
     virtual double get_tau() const { return tau; };
-
     virtual double get_ypar() const { return ypar; };
 
-    friend double comfnc(double ein, void* p);
-    friend double comint(double gam, void* p);
-    friend double disk_integral(double alfa, void* p);
+    virtual void reset();
+    virtual void urad_test();
+    virtual void test();
+
+    // -------------------------------------------------------------------------
+    // Legacy API — backwards compatibility wrappers
+    // The seed_arr parameter is accepted but ignored; set the energy grid
+    // explicitly with set_target_energy_array() / set_target_frequency_array()
+    // before calling these if needed.
+    // -------------------------------------------------------------------------
+
+    //! @deprecated Use set_target_energy_array() instead.
+    virtual void seed_freq_array(const std::vector<double>& seed_arr) {
+        set_target_energy_array(seed_arr);
+    }
+
+    //! @deprecated Use cyclosyn_seed(syn_energies, syn_number_rates) instead.
+    virtual void cyclosyn_seed(const std::vector<double>& /*seed_arr*/,
+                               const std::vector<double>& syn_energies,
+                               const std::vector<double>& syn_number_rates) {
+        cyclosyn_seed(syn_energies, syn_number_rates);
+    }
+
+    //! @deprecated Use bb_seed_k(Urad, Tbb) instead.
+    virtual void bb_seed_k(const std::vector<double>& /*seed_arr*/, double Urad, double Tbb) {
+        bb_seed_k(Urad, Tbb);
+    }
+
+    //! @deprecated Use bb_seed_kev(Urad, Tbb) instead.
+    virtual void bb_seed_kev(const std::vector<double>& /*seed_arr*/, double Urad, double Tbb) {
+        bb_seed_kev(Urad, Tbb);
+    }
+
+    //! @deprecated Use shsdisk_seed(tin, rin, rout, h, z) instead.
+    virtual void shsdisk_seed(const std::vector<double>& /*seed_arr*/, double tin, double rin,
+                              double rout, double h, double z) {
+        shsdisk_seed(tin, rin, rout, h, z);
+    }
 };
 
 }    // namespace kariba

--- a/src/kariba/Compton.hpp
+++ b/src/kariba/Compton.hpp
@@ -9,7 +9,7 @@ namespace kariba {
 //! Class inverse Compton, inherited from Radiation.hpp
 class Compton : public Radiation {
   protected:
-    double log_floor = -230; // about 1e-100 
+    static const double log_floor = -230; // about 1e-100 
     size_t Niter;          //!< number of IC iterations
     double tau, ypar;      //!< optical depth/comtpon Y of emitting region
     double rphot;          //!< photospheric radius when tau > 1, used to renormalize volume

--- a/src/kariba/Compton.hpp
+++ b/src/kariba/Compton.hpp
@@ -51,8 +51,6 @@ class Compton : public Radiation {
 
     virtual void set_target_energy_array(const std::vector<double>& new_target_energy);
     virtual void set_target_frequency_array(const std::vector<double>& new_target_frequency);
-    virtual void set_target_energy_array(const std::vector<double>& new_target_energy);
-    virtual void set_target_frequency_array(const std::vector<double>& new_target_frequency);
 
     virtual void add_target_diff_spec(const std::vector<double>& new_target_diff_spec);
     virtual void add_target_energy_density(
@@ -71,12 +69,6 @@ class Compton : public Radiation {
     virtual void bb_seed_kev(double Urad, double Tbb);
     virtual void shsdisk_seed(double tin, double rin, double rout, double h, double z);
 
-    virtual void set_niter(double nu0, double Te);
-    virtual void set_niter(size_t n);
-    virtual void set_tau(double n, double gam);
-    virtual void set_tau(double _tau);
-    virtual void set_frequency(double numin, double numax);
-    virtual void set_escape(double escape);
     virtual void set_niter(double nu0, double Te);
     virtual void set_niter(size_t n);
     virtual void set_tau(double n, double gam);

--- a/src/kariba/Compton.hpp
+++ b/src/kariba/Compton.hpp
@@ -9,6 +9,7 @@ namespace kariba {
 //! Class inverse Compton, inherited from Radiation.hpp
 class Compton : public Radiation {
   protected:
+    double log_floor = -230;
     size_t Niter;          //!< number of IC iterations
     double tau, ypar;      //!< optical depth/comtpon Y of emitting region
     double rphot;          //!< photospheric radius when tau > 1, used to renormalize volume
@@ -76,8 +77,8 @@ class Compton : public Radiation {
     virtual void set_frequency(double numin, double numax);
     virtual void set_escape(double escape);
 
-    virtual std::vector<double> get_target_energy();
-    virtual std::vector<double> get_target_diff_spec();
+    virtual std::vector<double> get_target_energy() const;
+    virtual std::vector<double> get_target_diff_spec() const;
 
     virtual double get_tau() const { return tau; };
     virtual double get_ypar() const { return ypar; };

--- a/src/kariba/Compton.hpp
+++ b/src/kariba/Compton.hpp
@@ -9,7 +9,7 @@ namespace kariba {
 //! Class inverse Compton, inherited from Radiation.hpp
 class Compton : public Radiation {
   protected:
-    static const double log_floor = -230; // about 1e-100 
+    const double log_floor = -230; // about 1e-100 
     size_t Niter;          //!< number of IC iterations
     double tau, ypar;      //!< optical depth/comtpon Y of emitting region
     double rphot;          //!< photospheric radius when tau > 1, used to renormalize volume

--- a/src/kariba/Compton.hpp
+++ b/src/kariba/Compton.hpp
@@ -43,6 +43,7 @@ class Compton : public Radiation {
 
     virtual void cyclosyn_seed(const std::vector<double>& seed_arr,
                                const std::vector<double>& seed_lum);
+    void add_seed(const std::vector<double>& seed_syn_energ, const std::vector<double>& seed_arr);
     virtual void bb_seed_k(const std::vector<double>& seed_arr, double Urad, double Tbb);
     virtual void bb_seed_kev(const std::vector<double>& seed_energ, double Urad, double Tbb);
     virtual void shsdisk_seed(const std::vector<double>& seed_arr, double tin, double rin,

--- a/src/kariba/Compton.hpp
+++ b/src/kariba/Compton.hpp
@@ -88,36 +88,27 @@ class Compton : public Radiation {
 
     // -------------------------------------------------------------------------
     // Legacy API — backwards compatibility wrappers
-    // The seed_arr parameter is accepted but ignored; set the energy grid
-    // explicitly with set_target_energy_array() / set_target_frequency_array()
-    // before calling these if needed.
+    // The seed_arr parameter sets the energy grid, but it is cleaner to set it
+    // explicitly with set_target_energy_array() / set_target_frequency_array().
     // -------------------------------------------------------------------------
 
-    //! @deprecated Use set_target_energy_array() instead.
-    virtual void seed_freq_array(const std::vector<double>& seed_arr) {
-        set_target_energy_array(seed_arr);
-    }
-
-    //! @deprecated Use cyclosyn_seed(syn_energies, syn_number_rates) instead.
-    virtual void cyclosyn_seed(const std::vector<double>& /*seed_arr*/,
-                               const std::vector<double>& syn_energies,
-                               const std::vector<double>& syn_number_rates) {
-        cyclosyn_seed(syn_energies, syn_number_rates);
-    }
 
     //! @deprecated Use bb_seed_k(Urad, Tbb) instead.
-    virtual void bb_seed_k(const std::vector<double>& /*seed_arr*/, double Urad, double Tbb) {
+    virtual void bb_seed_k(const std::vector<double>& seed_arr, double Urad, double Tbb) {
+        set_target_energy_array(seed_arr);
         bb_seed_k(Urad, Tbb);
     }
 
     //! @deprecated Use bb_seed_kev(Urad, Tbb) instead.
-    virtual void bb_seed_kev(const std::vector<double>& /*seed_arr*/, double Urad, double Tbb) {
+    virtual void bb_seed_kev(const std::vector<double>& seed_arr, double Urad, double Tbb) {
+        set_target_energy_array(seed_arr);
         bb_seed_kev(Urad, Tbb);
     }
 
     //! @deprecated Use shsdisk_seed(tin, rin, rout, h, z) instead.
-    virtual void shsdisk_seed(const std::vector<double>& /*seed_arr*/, double tin, double rin,
+    virtual void shsdisk_seed(const std::vector<double>& seed_arr, double tin, double rin,
                               double rout, double h, double z) {
+        set_target_energy_array(seed_arr);
         shsdisk_seed(tin, rin, rout, h, z);
     }
 };

--- a/src/kariba/Compton.hpp
+++ b/src/kariba/Compton.hpp
@@ -14,11 +14,11 @@ class Compton : public Radiation {
     double rphot;          //!< photospheric radius when tau > 1, used to renormalize volume
     double escape_corr;    //!< escape term, used to renormalize our spectra to CompPS
 
-    std::vector<double> log_target_energy;    //!< array of seed energies in erg
+    std::vector<double> target_energy;    //!< array of seed energies in erg
     std::vector<double> log_target_diff_spec;     //!< array of seed photon number density in log(#/erg/cm^3)
     std::vector<double>
         log_target_diff_spec_iter;    //!< array of iterated photon number density in log(#/erg/cm^3)
-    std::vector<double> log_energy_iter;
+
 
     gsl_spline* seed_ph;           //!< interpolation of photon field array target_diff_spec
     gsl_interp_accel* acc_seed;    //!< accelerator for above spline

--- a/src/kariba/Cyclosyn.hpp
+++ b/src/kariba/Cyclosyn.hpp
@@ -11,7 +11,7 @@ class Cyclosyn : public Radiation {
     double mass_gr;    // Mass of the emitting particle
     gsl_spline* syn_f;
     gsl_interp_accel* syn_acc;
-    std::vector<double> cyclosyn_abs;
+    std::vector<double> cyclosyn_absorption_rate;
 
   public:
     ~Cyclosyn();
@@ -36,7 +36,7 @@ class Cyclosyn : public Radiation {
     virtual void test();
 
     // friend double get_cyclosyn_emission() {return cyclosyn_emission;};
-    friend double get_cyclosyn_absorption_rate() {return cyclosyn_abs;};
+    friend double get_cyclosyn_absorption_rate() {return cyclosyn_absorption_rate;};
 };
 
 }    // namespace kariba

--- a/src/kariba/Cyclosyn.hpp
+++ b/src/kariba/Cyclosyn.hpp
@@ -35,8 +35,8 @@ class Cyclosyn : public Radiation {
 
     virtual void test();
 
-    // friend double get_cyclosyn_emission() const {return cyclosyn_emission;};
-    friend double get_cyclosyn_absorption_rate() const {return cyclosyn_abs;};
+    // friend double get_cyclosyn_emission() {return cyclosyn_emission;};
+    friend double get_cyclosyn_absorption_rate() {return cyclosyn_abs;};
 };
 
 }    // namespace kariba

--- a/src/kariba/Cyclosyn.hpp
+++ b/src/kariba/Cyclosyn.hpp
@@ -35,8 +35,10 @@ class Cyclosyn : public Radiation {
 
     virtual void test();
 
-    // friend double get_cyclosyn_emission() {return cyclosyn_emission;};
-    friend double get_cyclosyn_absorption_rate() {return cyclosyn_absorption_rate;};
+    const std::vector<double>& get_cyclosyn_absorption_rate() const { return cyclosyn_absorption_rate; }
+
+    friend double cyclosyn_emis(double gamma, void* pars);
+    friend double cyclosyn_abs(double gamma, void* pars);
 };
 
 }    // namespace kariba

--- a/src/kariba/Cyclosyn.hpp
+++ b/src/kariba/Cyclosyn.hpp
@@ -11,6 +11,7 @@ class Cyclosyn : public Radiation {
     double mass_gr;    // Mass of the emitting particle
     gsl_spline* syn_f;
     gsl_interp_accel* syn_acc;
+    std::vector<double> cyclosyn_abs;
 
   public:
     ~Cyclosyn();
@@ -34,8 +35,8 @@ class Cyclosyn : public Radiation {
 
     virtual void test();
 
-    friend double emis(double gamma, void* p);
-    friend double abs(double gamma, void* p);
+    // friend double get_cyclosyn_emission() const {return cyclosyn_emission;};
+    friend double get_cyclosyn_absorption_rate() const {return cyclosyn_abs;};
 };
 
 }    // namespace kariba

--- a/src/kariba/Radiation.hpp
+++ b/src/kariba/Radiation.hpp
@@ -36,6 +36,7 @@ struct ComintParams {
     gsl_interp_accel* acc_eldis;
     gsl_spline* phodis;
     gsl_interp_accel* acc_phodis;
+    gsl_integration_workspace* w2;
 };
 
 //! Structure used for GSL integration

--- a/src/kariba/Radiation.hpp
+++ b/src/kariba/Radiation.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include <gsl/gsl_spline.h>
+#include <gsl/gsl_integration.h>
 
 namespace kariba {
 


### PR DESCRIPTION
# Refactor seed photon field API and add new target field methods, minor cyclosyn. changes

## Summary
This PR refactors the internal representation and public API of the seed photon field in `Compton`, and adds several new methods for setting the target photon field from different input formats. Backwards compatibility with the old API is maintained via deprecated overloads. Added readout for syn-self-abs. time-scale.


## Changes

### Internal representation
- Renamed `seed_energ` → `target_energy`, `seed_urad` → `log_target_diff_spec`, `iter_urad` → `log_target_diff_spec_iter` for clarity
- Switched internal storage from **log10** to **natural log** space throughout, making the floor value `exp(-230) ≈ 1e-100` consistent everywhere (constructor, reset, set methods, and iteration floor)
- `gsl_integration_workspace` (`w1`, `w2`) are now class members allocated once in the constructor and freed in the destructor, rather than being allocated and freed on every integration call

### New public API
- `set_target_energy_array()` / `set_target_frequency_array()` — explicitly set the seed photon energy grid
- `add_target_diff_spec()` — add a differential target photon spectrum on the existing grid
- `add_target_energy_density()` / `add_target_number_density()` / `add_target_number_density_on_freq_grid()` — add a target field from different input conventions, with automatic interpolation onto the internal grid and clipping outside the provided range
- `get_target_energy()` / `get_target_diff_spec()` — getters for the seed photon field

### Bug fixes
- `compton_spectrum` now correctly uses `r * z` (cylinder) vs `r²` (sphere) in the denominator of the iterated photon field, rather than always using `r²`
- `reset()` previously filled `log_target_diff_spec`(formerly seed_urad) with `0` instead of the floor value

### Backwards compatibility
All old method signatures (`bb_seed_k`, `bb_seed_kev`, `shsdisk_seed`, `cyclosyn_seed` with leading `seed_arr` parameter, and `seed_freq_array`) are retained as deprecated overloads. The `seed_arr` parameter is ignored — the energy grid should be set explicitly via `set_target_energy_array()` beforehand.

### Cyclosyn
Added the array `cyclosyn_absorption_rate` that is filled to read out the absorption time scale. Added getter. 

### Gitignore
- removed DS_Store (MacOS) files from repo