### PR TITLE
Update synchrotron calculation

### DIFF
--- a/src/BBody.cpp
+++ b/src/BBody.cpp
@@ -7,30 +7,13 @@
 namespace kariba {
 
 BBody::BBody(size_t size) : Radiation(size) {}    // default of size = 40 in definition
-
 //! Methods to set BB quantities
-void BBody::set_temp_kev(double T) {
-    double emin, emax, einc;
-
-    Tbb = T * constants::kboltz_kev2erg / constants::kboltz;
-
-    emin = 0.02 * constants::kboltz * Tbb;
-    emax = 30. * constants::kboltz * Tbb;
-
-    einc = (std::log10(emax) - std::log10(emin)) / static_cast<double>(en_phot.size() - 1);
-
-    for (size_t i = 0; i < en_phot.size(); i++) {
-        en_phot[i] = std::pow(10., std::log10(emin) + static_cast<double>(i) * einc);
-        en_phot_obs[i] = en_phot[i];
-    }
-}
-
 void BBody::set_temp_k(double T) {
     double emin, emax, einc;
 
     Tbb = T;
 
-    emin = 0.02 * constants::kboltz * Tbb;
+    emin = 1e-3 * constants::kboltz * Tbb;
     emax = 30. * constants::kboltz * Tbb;
 
     einc = (std::log10(emax) - std::log10(emin)) / static_cast<double>(en_phot.size() - 1);
@@ -39,23 +22,16 @@ void BBody::set_temp_k(double T) {
         en_phot[i] = std::pow(10., std::log10(emin) + static_cast<double>(i) * einc);
         en_phot_obs[i] = en_phot[i];
     }
+}
+
+void BBody::set_temp_kev(double T) {
+    set_temp_k(T * constants::kboltz_kev2erg / constants::kboltz);
 }
 
 void BBody::set_temp_hz(double nu) {
-    double emin, emax, einc;
-
-    Tbb = (constants::herg * nu) / (2.82 * constants::kboltz);
-
-    emin = 0.02 * constants::kboltz * Tbb;
-    emax = 30. * constants::kboltz * Tbb;
-
-    einc = (std::log10(emax) - std::log10(emin)) / static_cast<double>(en_phot.size() - 1);
-
-    for (size_t i = 0; i < en_phot.size(); i++) {
-        en_phot[i] = std::pow(10., std::log10(emin) + static_cast<double>(i) * einc);
-        en_phot_obs[i] = en_phot[i];
-    }
+    set_temp_k((constants::herg * nu) / (2.82 * constants::kboltz));
 }
+
 
 void BBody::set_lum(double L) {
     Lbb = L;

--- a/src/Bknpower.cpp
+++ b/src/Bknpower.cpp
@@ -53,7 +53,7 @@ void Bknpower::set_ndens() {
                    (1. + std::pow(p[i] / pbrk, -pspec1 + pspec2)) * std::exp(-p[i] / pmax);
     }
     initialize_gdens();
-    gdens_differentiate();
+    differentiate();
 }
 
 //! methods to set the slopes, break and normalization
@@ -161,7 +161,7 @@ void Bknpower::cooling_steadystate(double ucom, double n0, double bfield, double
     }
 
     initialize_gdens();
-    gdens_differentiate();
+    differentiate();
 }
 
 //! Method to calculate maximum momentum of non thermal particles based on

--- a/src/Cyclosyn.cpp
+++ b/src/Cyclosyn.cpp
@@ -51,25 +51,25 @@ double cyclosyn_kernel(double gamma, double nu, double b, gsl_spline* syn, gsl_i
                (4. * constants::pi * constants::emgm * constants::cee);
         x = nu / nu_c;
         // This is F(x) , which is not pitch angle averaged
-        // if (x <= 1.e-4) {
-        //     emisfunc = 4. * constants::pi * std::cbrt(x / 2.) / (sqrt(3.) * 2.68);
-        // } else if (x > 50.) {
-        //     emisfunc = sqrt(constants::pi * x / 2.) * std::exp(-x);
-        // } else {
-        //     emisfunc = std::pow(10., gsl_spline_eval(syn, x, acc_syn));
+        if (x <= 1.e-4) {
+            emisfunc = 4. * constants::pi * std::cbrt(x / 2.) / (sqrt(3.) * 2.68);
+        } else if (x > 50.) {
+            emisfunc = sqrt(constants::pi * x / 2.) * std::exp(-x);
+        } else {
+            emisfunc = std::pow(10., gsl_spline_eval(syn, x, acc_syn));
+        }
+        // if (x <= 700) {
+        //     double x13 = std::cbrt(x);   // more stable than pow(x, 1./3.)
+        //     double x23 = x13 * x13;
+        //     double x43 = x23 * x23;
+        //     double t1 = 1.808 * x13 / std::sqrt(1 + 3.4 * x23);
+        //     double t2 = 1 + 2.21 * x23  + 0.347 * x43;
+        //     double t3 = 1 + 1.353 * x23  + 0.217 * x43;
+        //     emisfunc = t1 * t2 / t3 * std::exp(-x);
         // }
-        if (x <= 700) {
-            double x13 = std::cbrt(x);   // more stable than pow(x, 1./3.)
-            double x23 = x13 * x13;
-            double x43 = x23 * x23;
-            double t1 = 1.808 * x13 / std::sqrt(1 + 3.4 * x23);
-            double t2 = 1 + 2.21 * x23  + 0.347 * x43;
-            double t3 = 1 + 1.353 * x23  + 0.217 * x43;
-            emisfunc = t1 * t2 / t3 * std::exp(-x);
-        }
-        else {
-            emisfunc = 1e-305; // floor, = 0
-        }
+        // else {
+        //     emisfunc = 1e-305; // floor, = 0
+        // }
     } else {    // cyclotron regime
         nu_larmor =
             (constants::charg * b) / (2. * constants::pi * constants::emgm * constants::cee);

--- a/src/Cyclosyn.cpp
+++ b/src/Cyclosyn.cpp
@@ -65,7 +65,7 @@ double cyclosyn_kernel(double gamma, double nu, double b, gsl_spline* syn, gsl_i
             double t1 = 1.808 * x13 / std::sqrt(1 + 3.4 * x23);
             double t2 = 1 + 2.21 * x23  + 0.347 * x43;
             double t3 = 1 + 1.353 * x23  + 0.217 * x43;
-            emisfunc = t1 * t2 / t3 * std::exp(-x)
+            emisfunc = t1 * t2 / t3 * std::exp(-x);
         }
         else {
             emisfunc = 1e-305; // floor, = 0
@@ -210,7 +210,7 @@ void Cyclosyn::cycsyn_spectrum(double gmin, double gmax, gsl_spline* eldis,
             }
             tau_syn = t_esc * alpha_abs;
             // numerically stable -( exp(-tsyn) - 1 )
-            absfac = - std::expm1(-tsyn);
+            absfac = - std::expm1(-tau_syn);
             // observed opacities changed by doppler factor and viewing angle
             tau_syn_obs = tau_syn / dopfac;
             if (geometry == "cylinder") {

--- a/src/Cyclosyn.cpp
+++ b/src/Cyclosyn.cpp
@@ -109,14 +109,15 @@ double cyclosyn_abs(double log_rho, void* pars) {
     gsl_spline* derivs = (params->derivs);
     gsl_interp_accel* acc_derivs = (params->acc_derivs);
 
-    double gamma, rho, emisfunc, pdensp2_diff_logp, nlogp, norm_em, norm_ab;
+    double gamma, rho, emisfunc, pdensp2_diff_logp, nlogp, norm_em, norm_ab, fac_p;
     gamma = std::sqrt(std::exp(2*log_rho) + 1);
     rho = std::exp(log_rho);
     emisfunc = cyclosyn_kernel(gamma, nu, b, syn, acc_syn);
     pdensp2_diff_logp = gsl_spline_eval(derivs, gamma, acc_derivs);
     norm_em = sqrt(3.) * std::pow(constants::charg, 3) * b / constants::emerg;
-    norm_ab = - std::pow(constants::cee / nu, 2.) / (8. * constants::pi);
-    return norm_ab * pdensp2_diff_logp * gamma * rho * emisfunc * norm_em;
+    norm_ab = - std::pow(nu, -2.) / (8. * constants::pi * constants::emgm);
+    fac_p = std::pow(constants::emgm * constants::cee, 3);
+    return norm_ab * pdensp2_diff_logp * gamma * rho * emisfunc * norm_em * fac_p;
 }
 
 //! Integrals of single particle emissivity/absorption coefficient over particle

--- a/src/Cyclosyn.cpp
+++ b/src/Cyclosyn.cpp
@@ -209,7 +209,7 @@ void Cyclosyn::cycsyn_spectrum(double gmin, double gmax, gsl_spline* eldis,
             } else {
                 l_average *= constants::pi / 3.;
             }
-            double t_esc = l_average / constants::c; 
+            double t_esc = l_average / constants::cee; 
             tau_syn = l_average * alpha_abs;
             // numerically stable -( exp(-tsyn) - 1 )
             absfac = - std::expm1(-tau_syn);

--- a/src/Cyclosyn.cpp
+++ b/src/Cyclosyn.cpp
@@ -109,6 +109,7 @@ double cyclosyn_abs(double log_rho, void* pars) {
     gsl_spline* derivs = (params->derivs);
     gsl_interp_accel* acc_derivs = (params->acc_derivs);
 
+    // using eg. Ghisellini & Svensson 1991, eq 1
     double gamma, rho, emisfunc, pdensp2_diff_logp, nlogp, norm_em, norm_ab, fac_p;
     gamma = std::sqrt(std::exp(2*log_rho) + 1);
     rho = std::exp(log_rho);

--- a/src/Cyclosyn.cpp
+++ b/src/Cyclosyn.cpp
@@ -223,7 +223,7 @@ void Cyclosyn::cycsyn_spectrum(double gmin, double gmax, gsl_spline* eldis,
             num_phot[k] =  cross_section_circle * absfac * j_emis/alpha_abs;
             double projected_area = 2. * r * z;
             // num_phot_obs[k] = projected_area * absfac_obs * j_emis * std::pow(dopfac, dopnum);
-            num_phot_obs[k] = projected_area * t_esc * j_emis * std::pow(dopfac, dopnum);
+            num_phot_obs[k] = projected_area * r* t_esc * j_emis * std::pow(dopfac, dopnum);
 
             if (counterjet == true) {
                 tau_syn_obs *= dopfac/dopfac_cj;

--- a/src/Cyclosyn.cpp
+++ b/src/Cyclosyn.cpp
@@ -41,8 +41,48 @@ Cyclosyn::Cyclosyn(size_t size) : Radiation(size) {
     gsl_spline_init(syn_f, arg, var, 47);
 }
 
+double cyclosyn_kernel(double gamma, double nu, double b, gsl_spline* syn, gsl_interp_accel* acc_syn) {
+    double nu_c, x, emisfunc, nu_larmor, psquared;
+    // this is in the synchrotron regime
+    // use the approximation for the pitch angle averaged version from 
+    // Aharonian, Kelner & Prosekin 2010, D7
+    if (gamma > 2.) {
+        nu_c = (3. * constants::charg * b * std::pow(gamma, 2.)) /
+               (4. * constants::pi * constants::emgm * constants::cee);
+        x = nu / nu_c;
+        // This is F(x) , which is not pitch angle averaged
+        // if (x <= 1.e-4) {
+        //     emisfunc = 4. * constants::pi * std::cbrt(x / 2.) / (sqrt(3.) * 2.68);
+        // } else if (x > 50.) {
+        //     emisfunc = sqrt(constants::pi * x / 2.) * std::exp(-x);
+        // } else {
+        //     emisfunc = std::pow(10., gsl_spline_eval(syn, x, acc_syn));
+        // }
+        if (x <= 700) {
+            double x13 = std::cbrt(x);   // more stable than pow(x, 1./3.)
+            double x23 = x13 * x13;
+            double x43 = x23 * x23;
+            double t1 = 1.808 * x13 / std::sqrt(1 + 3.4 * x23);
+            double t2 = 1 + 2.21 * x23  + 0.347 * x43;
+            double t3 = 1 + 1.353 * x23  + 0.217 * x43;
+            emisfunc = t1 * t2 / t3 * std::exp(-x)
+        }
+        else {
+            emisfunc = 1e-305; // floor, = 0
+        }
+    } else {    // cyclotron regime
+        nu_larmor =
+            (constants::charg * b) / (2. * constants::pi * constants::emgm * constants::cee);
+        x = nu / nu_larmor;
+        psquared = std::pow(gamma, 2.) - 1.;
+        emisfunc = (2. * psquared) / (1. + 3. * psquared) *
+                   std::exp((2. * (1. - x)) / (1. + 3. * psquared));
+    }
+    return emisfunc;
+}
+
 //! Single particle emissivity/absorption coefficient calculations
-double cyclosyn_emis(double gamma, void* pars) {
+double cyclosyn_emis(double log_rho, void* pars) {
     CyclosynEmisParams* params = static_cast<CyclosynEmisParams*>(pars);
     double nu = params->nu;
     double b = params->b;
@@ -51,35 +91,16 @@ double cyclosyn_emis(double gamma, void* pars) {
     gsl_spline* eldis = params->eldis;
     gsl_interp_accel* acc_eldis = params->acc_eldis;
 
-    double nu_c, x, emisfunc, nu_larmor, psquared, ngamma;
-    gamma = std::exp(gamma);
-    // this is in the synchrotron regime
-    if (gamma > 2.) {
-        nu_c = (3. * constants::charg * b * std::pow(gamma, 2.)) /
-               (4. * constants::pi * constants::emgm * constants::cee);
-        x = nu / nu_c;
-        if (x <= 1.e-4) {
-            emisfunc = 4. * constants::pi * std::pow(x / 2., (1. / 3.)) / (sqrt(3.) * 2.68);
-        } else if (x > 50.) {
-            emisfunc = sqrt(constants::pi * x / 2.) * std::exp(-x);
-        } else {
-            emisfunc = std::pow(10., gsl_spline_eval(syn, x, acc_syn));
-        }
-    } else {    // cyclotron regime
-        nu_larmor =
-            (constants::charg * b) / (2. * constants::pi * constants::emgm * constants::cee);
-        x = nu / nu_larmor;
-        psquared = std::pow(gamma, 2.) - 1.;
-        emisfunc = (2. * psquared) / (1. + 3. * psquared) *
-                   std::exp((2. * (1. - x)) / (1. + 3. * psquared));
-    }
-
+    double gamma, emisfunc, ngamma, nlogp, norm_em;
+    gamma = std::sqrt(std::exp(2*log_rho) + 1);
+    emisfunc = cyclosyn_kernel(gamma, nu, b, syn, acc_syn);
     ngamma = gsl_spline_eval(eldis, gamma, acc_eldis);
-
-    return ngamma * gamma * emisfunc;
+    nlogp = (gamma*gamma - 1)/gamma * ngamma; // dn/dlogp = p dn/dp = p dgamma/dp dn/dgamma
+    norm_em = sqrt(3.) * std::pow(constants::charg, 3) * b / constants::emerg;
+    return nlogp * emisfunc * norm_em;
 }
 
-double cyclosyn_abs(double gamma, void* pars) {
+double cyclosyn_abs(double log_rho, void* pars) {
     CyclosynAbsParams* params = static_cast<CyclosynAbsParams*>(pars);
     double nu = (params->nu);
     double b = (params->b);
@@ -88,31 +109,14 @@ double cyclosyn_abs(double gamma, void* pars) {
     gsl_spline* derivs = (params->derivs);
     gsl_interp_accel* acc_derivs = (params->acc_derivs);
 
-    double nu_c, x, emisfunc, nu_larmor, psquared, ngamma_diff;
-    gamma = std::exp(gamma);
-    // this is in the synchrotron regime
-    if (gamma > 2.) {
-        nu_c = (3. * constants::charg * b * std::pow(gamma, 2.)) /
-               (4. * constants::pi * constants::emgm * constants::cee);
-        x = nu / nu_c;
-        if (x <= 1.e-4) {
-            emisfunc = 4. * constants::pi * std::pow(x / 2., (1. / 3.)) / (sqrt(3.) * 2.68);
-        } else if (x > 50.) {
-            emisfunc = sqrt(constants::pi * x / 2.) * std::exp(-x);
-        } else {
-            emisfunc = std::pow(10., gsl_spline_eval(syn, x, acc_syn));
-        }
-    } else {    // cyclotron regime
-        nu_larmor =
-            (constants::charg * b) / (2. * constants::pi * constants::emgm * constants::cee);
-        x = nu / nu_larmor;
-        psquared = std::pow(gamma, 2.) - 1.;
-        emisfunc = (2. * psquared) / (1. + 3. * psquared) *
-                   std::exp((2. * (1. - x)) / (1. + 3. * psquared));
-    }
-    ngamma_diff = gsl_spline_eval(derivs, gamma, acc_derivs);
-
-    return ngamma_diff * std::pow(gamma, 2.) * emisfunc;
+    double gamma, rho, emisfunc, pdensp2_diff_logp, nlogp, norm_em, norm_ab;
+    gamma = std::sqrt(std::exp(2*log_rho) + 1);
+    rho = std::exp(log_rho);
+    emisfunc = cyclosyn_kernel(gamma, nu, b, syn, acc_syn);
+    pdensp2_diff_logp = gsl_spline_eval(derivs, gamma, acc_derivs);
+    norm_em = sqrt(3.) * std::pow(constants::charg, 3) * b / constants::emerg;
+    norm_ab = - std::pow(constants::cee / nu, 2.) / (8. * constants::pi);
+    return norm_ab * pdensp2_diff_logp * gamma * rho * emisfunc * norm_em;
 }
 
 //! Integrals of single particle emissivity/absorption coefficient over particle
@@ -126,7 +130,9 @@ double Cyclosyn::emis_integral(double nu, double gmin, double gmax, gsl_spline* 
     auto F1params = CyclosynEmisParams{nu, bfield, syn_f, syn_acc, eldis, acc_eldis};
     F1.function = &cyclosyn_emis;
     F1.params = &F1params;
-    gsl_integration_qag(&F1, std::log(gmin), std::log(gmax), 1e1, 1e1, 100, 2, w1, &result1,
+    double rho_min = std::sqrt(gmin*gmin - 1);
+    double rho_max = std::sqrt(gmax*gmax - 1);
+    gsl_integration_qag(&F1, std::log(rho_min), std::log(rho_max), 1e1, 1e1, 100, 2, w1, &result1,
                         &error1);
     gsl_integration_workspace_free(w1);
 
@@ -142,7 +148,9 @@ double Cyclosyn::abs_integral(double nu, double gmin, double gmax, gsl_spline* d
     auto F1params = CyclosynAbsParams{nu, bfield, syn_f, syn_acc, derivs, acc_derivs};
     F1.function = &cyclosyn_abs;
     F1.params = &F1params;
-    gsl_integration_qag(&F1, std::log(gmin), std::log(gmax), 1e1, 1e1, 100, 2, w1, &result1,
+    double rho_min = std::sqrt(gmin*gmin - 1);
+    double rho_max = std::sqrt(gmax*gmax - 1);
+    gsl_integration_qag(&F1, std::log(rho_min), std::log(rho_max), 1e1, 1e1, 100, 2, w1, &result1,
                         &error1);
     gsl_integration_workspace_free(w1);
 
@@ -153,10 +161,10 @@ double Cyclosyn::abs_integral(double nu, double gmin, double gmax, gsl_spline* d
 void Cyclosyn::cycsyn_spectrum(double gmin, double gmax, gsl_spline* eldis,
                                gsl_interp_accel* acc_eldis, gsl_spline* eldis_diff,
                                gsl_interp_accel* acc_eldis_diff) {
-    double emis, abs;
-    double pitch = 0.73;
-    double acons, elcons, asyn, epsasyn;
-    double absfac, tsyn, tsyn_obs, absfac_obs;
+    double j_emis, alpha_abs;
+    // double pitch = 0.73;
+    // double acons, elcons, asyn, epsasyn;
+    double absfac, tau_syn, tau_syn_obs, absfac_obs;
     double dopfac_cj;
 
     dopfac_cj = dopfac * (1. - beta * cos(angle)) / (1. + beta * cos(angle));
@@ -167,57 +175,58 @@ void Cyclosyn::cycsyn_spectrum(double gmin, double gmax, gsl_spline* eldis,
         if (counterjet == true) {
             en_phot_obs[k + size] = en_phot[k] * dopfac_cj;
         }
-        emis = emis_integral(en_phot[k] / constants::herg, gmin, gmax, eldis, acc_eldis);
-        abs = abs_integral(en_phot[k] / constants::herg, gmin, gmax, eldis_diff, acc_eldis_diff);
-        if (std::log10(emis) < -50. || std::log10(abs) < -50.) {
+        j_emis = emis_integral(en_phot[k] / constants::herg, gmin, gmax, eldis, acc_eldis);
+        alpha_abs = abs_integral(en_phot[k] / constants::herg, gmin, gmax, eldis_diff, acc_eldis_diff);
+        if (std::log10(j_emis) < -150. || std::log10(alpha_abs) < -150.) {
             num_phot_obs[k] = 0;
             if (counterjet == true) {
                 num_phot_obs[k + size] = 0;
             }
         } else {
-            elcons = sqrt(3.) * (constants::charg * constants::charg * constants::charg) * bfield *
-                     sin(pitch) / constants::emerg;
-            acons = -constants::cee * constants::cee /
-                    (8. * constants::pi * std::pow(en_phot[k] / constants::herg, 2.));
-            asyn = acons * elcons * abs;
-            cyclosyn_absorption_rate[k] = asyn * constants::cee * constants::pi;
-            epsasyn = emis / (acons * abs);
-            if (geometry == "cylinder") {
-                tsyn = constants::pi / 2. * asyn * r;
-            } else {
-                tsyn = constants::pi / 3. * asyn * r;
-            }
-            if (tsyn >= 1.) {
-                absfac = (1. - std::exp(-tsyn));
-            } else {
-                absfac = tsyn - std::pow(tsyn, 2.) / 2. + std::pow(tsyn, 3.) / 6.;
-            }
-            // This includes skin depth/viewing angle effects for cylinder case
-            if (geometry == "cylinder") {
-                tsyn_obs = constants::pi / 2. * asyn * r / (dopfac * sin(angle));
-            } else {
-                tsyn_obs = constants::pi / 3. * asyn * r;
-            }
-            // numerically stable -( exp(-tsyn) - 1 )
-            absfac_obs = - std::expm1(-tsyn_obs);
+            // elcons = sqrt(3.) * (constants::charg * constants::charg * constants::charg) * bfield *
+            //          sin(pitch) / constants::emerg;
+            // acons = -constants::cee * constants::cee /
+            //         (8. * constants::pi * std::pow(en_phot[k] / constants::herg, 2.));
+            // asyn = acons * elcons * abs;
+            // cyclosyn_absorption_rate[k] = asyn * constants::cee * constants::pi;
+            
+            // epsasyn = emis / (acons * abs);
+            
+            // // This includes skin depth/viewing angle effects for cylinder case
 
-            num_phot[k] = constants::pi * r * r * absfac * epsasyn;
-            num_phot_obs[k] = 2. * r * z * absfac_obs * epsasyn * std::pow(dopfac, dopnum);
+            // if (geometry == "cylinder") {
+            //     tsyn_obs = constants::pi / 2. * asyn * r / (dopfac * sin(angle));
+            // } else {
+            //     tsyn_obs = constants::pi / 3. * asyn * r;
+            // }
+
+            cyclosyn_absorption_rate[k] = alpha_abs;
+            double t_esc = r / constants::cee; 
+            // average path lengths
+            if (geometry == "cylinder") {
+                t_esc *= constants::pi / 2.;
+            } else {
+                t_esc *= constants::pi / 3.;
+            }
+            tau_syn = t_esc * alpha_abs;
+            // numerically stable -( exp(-tsyn) - 1 )
+            absfac = - std::expm1(-tsyn);
+            // observed opacities changed by doppler factor and viewing angle
+            tau_syn_obs = tau_syn / dopfac;
+            if (geometry == "cylinder") {
+                tau_syn_obs \= sin(angle); // this is spooky for theta = 0 ? 
+            }
+            absfac_obs = - std::expm1(-tau_syn_obs);
+            double cross_section_circle = constants::pi * r * r;
+            // photon
+            num_phot[k] =  cross_section_circle * absfac * j_emis/alpha_abs;
+            double projected_area = 2. * r * z;
+            num_phot_obs[k] = projected_area * absfac_obs * j_emis * std::pow(dopfac, dopnum);
 
             if (counterjet == true) {
-                if (geometry == "cylinder") {
-                    tsyn_obs = constants::pi / 2. * asyn * r / (dopfac * sin(angle));
-                } else {
-                    tsyn_obs = constants::pi / 3. * asyn * r;
-                }
-                if (tsyn_obs >= 1.) {
-                    absfac_obs = (1. - std::exp(-tsyn_obs));
-                } else {
-                    absfac_obs =
-                        tsyn_obs - std::pow(tsyn_obs, 2.) / 2. + std::pow(tsyn_obs, 3.) / 6.;
-                }
-                num_phot_obs[k + size] =
-                    2. * r * z * absfac_obs * epsasyn * std::pow(dopfac_cj, dopnum);
+                tau_syn_obs *= dopfac/dopfac_cj;
+                absfac_obs = - std::expm1(-tau_syn_obs);
+                num_phot_obs[k + size] = projected_area * absfac_obs * j_emis * std::pow(dopfac_cj, dopnum);
             } else {
                 num_phot_obs[k + size] = 0.;
             }

--- a/src/Cyclosyn.cpp
+++ b/src/Cyclosyn.cpp
@@ -201,7 +201,7 @@ void Cyclosyn::cycsyn_spectrum(double gmin, double gmax, gsl_spline* eldis,
             //     tsyn_obs = constants::pi / 3. * asyn * r;
             // }
 
-            cyclosyn_absorption_rate[k] = alpha_abs / constants::cee;
+            cyclosyn_absorption_rate[k] = alpha_abs * constants::cee;
             double l_average = r;
             // average path lengths
             if (geometry == "cylinder") {

--- a/src/Cyclosyn.cpp
+++ b/src/Cyclosyn.cpp
@@ -116,8 +116,8 @@ double cyclosyn_abs(double log_rho, void* pars) {
     pdensp2_diff_logp = gsl_spline_eval(derivs, gamma, acc_derivs);
     norm_em = sqrt(3.) * std::pow(constants::charg, 3) * b / constants::emerg;
     norm_ab = - std::pow(nu, -2.) / (8. * constants::pi * constants::emgm);
-    fac_p = std::pow(constants::emgm * constants::cee, 3);
-    return norm_ab * pdensp2_diff_logp * gamma * rho * emisfunc * norm_em * fac_p;
+    fac_p = std::pow(constants::emgm * constants::cee, 3); // from p to rho
+    return norm_ab * gamma * rho * norm_em * emisfunc * pdensp2_diff_logp * fac_p;
 }
 
 //! Integrals of single particle emissivity/absorption coefficient over particle
@@ -201,15 +201,16 @@ void Cyclosyn::cycsyn_spectrum(double gmin, double gmax, gsl_spline* eldis,
             //     tsyn_obs = constants::pi / 3. * asyn * r;
             // }
 
-            cyclosyn_absorption_rate[k] = alpha_abs;
-            double t_esc = r / constants::cee; 
+            cyclosyn_absorption_rate[k] = alpha_abs / constants::cee;
+            double l_average = r;
             // average path lengths
             if (geometry == "cylinder") {
-                t_esc *= constants::pi / 2.;
+                l_average *= constants::pi / 2.;
             } else {
-                t_esc *= constants::pi / 3.;
+                l_average *= constants::pi / 3.;
             }
-            tau_syn = t_esc * alpha_abs;
+            double t_esc = l_average / constants::c; 
+            tau_syn = l_average * alpha_abs;
             // numerically stable -( exp(-tsyn) - 1 )
             absfac = - std::expm1(-tau_syn);
             // observed opacities changed by doppler factor and viewing angle
@@ -217,17 +218,16 @@ void Cyclosyn::cycsyn_spectrum(double gmin, double gmax, gsl_spline* eldis,
             if (geometry == "cylinder") {
                 tau_syn_obs *= 1/sin(angle); // this is spooky for theta = 0 ? 
             }
-            absfac_obs = - std::expm1(-tau_syn_obs);
+            absfac_obs = - std::expm1(-tau_syn_obs) / alpha_abs;
             double cross_section_circle = constants::pi * r * r;
-            // photon
             num_phot[k] =  cross_section_circle * absfac * j_emis/alpha_abs;
-            double projected_area = 2. * r * z;
-            // num_phot_obs[k] = projected_area * absfac_obs * j_emis * std::pow(dopfac, dopnum);
-            num_phot_obs[k] = projected_area * r* t_esc * j_emis * std::pow(dopfac, dopnum);
+            double projected_area = 2. * r * z; // diameter * height -> lacks projection for headon?
+            num_phot_obs[k] = projected_area * absfac_obs * j_emis * std::pow(dopfac, dopnum);
+            // num_phot_obs[k] = projected_area * r* t_esc * j_emis * std::pow(dopfac, dopnum);
 
             if (counterjet == true) {
                 tau_syn_obs *= dopfac/dopfac_cj;
-                absfac_obs = - std::expm1(-tau_syn_obs);
+                absfac_obs = - std::expm1(-tau_syn_obs) / alpha_abs;
                 num_phot_obs[k + size] = projected_area * absfac_obs * j_emis * std::pow(dopfac_cj, dopnum);
             } else {
                 num_phot_obs[k + size] = 0.;

--- a/src/Cyclosyn.cpp
+++ b/src/Cyclosyn.cpp
@@ -51,25 +51,25 @@ double cyclosyn_kernel(double gamma, double nu, double b, gsl_spline* syn, gsl_i
                (4. * constants::pi * constants::emgm * constants::cee);
         x = nu / nu_c;
         // This is F(x) , which is not pitch angle averaged
-        if (x <= 1.e-4) {
-            emisfunc = 4. * constants::pi * std::cbrt(x / 2.) / (sqrt(3.) * 2.68);
-        } else if (x > 50.) {
-            emisfunc = sqrt(constants::pi * x / 2.) * std::exp(-x);
-        } else {
-            emisfunc = std::pow(10., gsl_spline_eval(syn, x, acc_syn));
+        // if (x <= 1.e-4) {
+        //     emisfunc = 4. * constants::pi * std::cbrt(x / 2.) / (sqrt(3.) * 2.68);
+        // } else if (x > 50.) {
+        //     emisfunc = sqrt(constants::pi * x / 2.) * std::exp(-x);
+        // } else {
+        //     emisfunc = std::pow(10., gsl_spline_eval(syn, x, acc_syn));
+        // }
+        if (x <= 700) {
+            double x13 = std::cbrt(x);   // more stable than pow(x, 1./3.)
+            double x23 = x13 * x13;
+            double x43 = x23 * x23;
+            double t1 = 1.808 * x13 / std::sqrt(1 + 3.4 * x23);
+            double t2 = 1 + 2.21 * x23  + 0.347 * x43;
+            double t3 = 1 + 1.353 * x23  + 0.217 * x43;
+            emisfunc = t1 * t2 / t3 * std::exp(-x);
         }
-        // if (x <= 700) {
-        //     double x13 = std::cbrt(x);   // more stable than pow(x, 1./3.)
-        //     double x23 = x13 * x13;
-        //     double x43 = x23 * x23;
-        //     double t1 = 1.808 * x13 / std::sqrt(1 + 3.4 * x23);
-        //     double t2 = 1 + 2.21 * x23  + 0.347 * x43;
-        //     double t3 = 1 + 1.353 * x23  + 0.217 * x43;
-        //     emisfunc = t1 * t2 / t3 * std::exp(-x);
-        // }
-        // else {
-        //     emisfunc = 1e-305; // floor, = 0
-        // }
+        else {
+            emisfunc = 1e-305; // floor, = 0
+        }
     } else {    // cyclotron regime
         nu_larmor =
             (constants::charg * b) / (2. * constants::pi * constants::emgm * constants::cee);
@@ -222,7 +222,8 @@ void Cyclosyn::cycsyn_spectrum(double gmin, double gmax, gsl_spline* eldis,
             // photon
             num_phot[k] =  cross_section_circle * absfac * j_emis/alpha_abs;
             double projected_area = 2. * r * z;
-            num_phot_obs[k] = projected_area * absfac_obs * j_emis * std::pow(dopfac, dopnum);
+            // num_phot_obs[k] = projected_area * absfac_obs * j_emis * std::pow(dopfac, dopnum);
+            num_phot_obs[k] = projected_area * t_esc * j_emis * std::pow(dopfac, dopnum);
 
             if (counterjet == true) {
                 tau_syn_obs *= dopfac/dopfac_cj;

--- a/src/Cyclosyn.cpp
+++ b/src/Cyclosyn.cpp
@@ -214,7 +214,7 @@ void Cyclosyn::cycsyn_spectrum(double gmin, double gmax, gsl_spline* eldis,
             // observed opacities changed by doppler factor and viewing angle
             tau_syn_obs = tau_syn / dopfac;
             if (geometry == "cylinder") {
-                tau_syn_obs \= sin(angle); // this is spooky for theta = 0 ? 
+                tau_syn_obs *= 1/sin(angle); // this is spooky for theta = 0 ? 
             }
             absfac_obs = - std::expm1(-tau_syn_obs);
             double cross_section_circle = constants::pi * r * r;

--- a/src/Kappa.cpp
+++ b/src/Kappa.cpp
@@ -65,7 +65,7 @@ void Kappa::set_ndens() {
                    std::pow(1. + (gamma[i] - 1.) / (kappa * theta), -kappa - 1.);
     }
     initialize_pdens();
-    gdens_differentiate();
+    differentiate();
 }
 
 //! Methods to calculate the normalization of the function
@@ -157,7 +157,7 @@ void Kappa::cooling_steadystate(double ucom, double n0, double bfield, double r,
     }
 
     initialize_gdens();
-    gdens_differentiate();
+    differentiate();
 }
 
 //! Method to calculate maximum momentum of non thermal particles based on

--- a/src/Mixed.cpp
+++ b/src/Mixed.cpp
@@ -54,7 +54,7 @@ void Mixed::set_ndens() {
             ndens[i] = thnorm * std::pow(p[i], 2.) * std::exp(-gamma[i] / theta) +
                        plnorm * std::pow(p[i], -pspec) * std::exp(-p[i] / pmax_pl) * std::exp(-std::pow(pmin_pl / p[i], 3));
         } else {
-            ndens[i] = plnorm * std::pow(p[i], -pspec) * std::exp(-p[i] / pmax_pl) * std::exp(-std::pow(pmin_pl / p[i]));
+            ndens[i] = plnorm * std::pow(p[i], -pspec) * std::exp(-p[i] / pmax_pl) * std::exp(-std::pow(pmin_pl / p[i], 3));
         }
     }
     initialize_gdens();

--- a/src/Mixed.cpp
+++ b/src/Mixed.cpp
@@ -48,7 +48,7 @@ void Mixed::set_p(double gmax) {
 
 void Mixed::set_ndens() {
     for (size_t i = 0; i < p.size(); i++) {
-        if (p[i] <= pmin_pl) {
+        if (p[i] <= pmin_pl / 10) {
             ndens[i] = thnorm * std::pow(p[i], 2.) * std::exp(-gamma[i] / theta);
         } else if (p[i] < pmax_th) {
             ndens[i] = thnorm * std::pow(p[i], 2.) * std::exp(-gamma[i] / theta) +
@@ -326,7 +326,7 @@ double injection_mixed_int(double x, void* pars) {
 
     double mom_int = std::pow(std::pow(x, 2.) - 1., 1. / 2.) * m * constants::cee;
 
-    if (x <= min) {
+    if (x <= min / 10) {
         return nth * std::pow(mom_int, 2.) * std::exp(-x / t);
     } else if (x < max) {
         return nth * std::pow(mom_int, 2.) * std::exp(-x / t) +

--- a/src/Mixed.cpp
+++ b/src/Mixed.cpp
@@ -52,9 +52,9 @@ void Mixed::set_ndens() {
             ndens[i] = thnorm * std::pow(p[i], 2.) * std::exp(-gamma[i] / theta);
         } else if (p[i] < pmax_th) {
             ndens[i] = thnorm * std::pow(p[i], 2.) * std::exp(-gamma[i] / theta) +
-                       plnorm * std::pow(p[i], -pspec) * std::exp(-p[i] / pmax_pl) * std::exp(-pmin_pl / p[i]);
+                       plnorm * std::pow(p[i], -pspec) * std::exp(-p[i] / pmax_pl) * std::exp(-std::pow(pmin_pl / p[i], 3));
         } else {
-            ndens[i] = plnorm * std::pow(p[i], -pspec) * std::exp(-p[i] / pmax_pl) * std::exp(-pmin_pl / p[i]);
+            ndens[i] = plnorm * std::pow(p[i], -pspec) * std::exp(-p[i] / pmax_pl) * std::exp(-std::pow(pmin_pl / p[i]));
         }
     }
     initialize_gdens();
@@ -88,14 +88,14 @@ void Mixed::set_plfrac(double Le, double r, double eldens) {
     double sum = 0;
     double dx = std::log10(gamma[2] / gamma[1]);
     for (size_t i = 0; i < p.size(); i++) {
-        sum += std::log(10.) * std::pow(gamma[i], -pspec + 2.) * std::exp(-gamma[i] / gpmax) * std::exp(-gpmin / gamma[i]) * dx;
+        sum += std::log(10.) * std::pow(gamma[i], -pspec + 2.) * std::exp(-gamma[i] / gpmax) * std::exp(-std::pow(gpmin / gamma[i], 3)) * dx;
     }
     double Ue = Le / (constants::pi * r * r * constants::cee);
     double K = std::max(Ue / (sum * mass_gr * constants::cee * constants::cee), 0.);
 
     sum = 0.;
     for (size_t i = 0; i < gamma.size(); i++) {
-        sum += std::log(10.) * std::pow(gamma[i], -pspec + 1.) * std::exp(-gamma[i] / gpmax) * std::exp(-gpmin / gamma[i]) * dx;
+        sum += std::log(10.) * std::pow(gamma[i], -pspec + 1.) * std::exp(-gamma[i] / gpmax) * std::exp(-std::pow(gpmin / gamma[i], 3)) * dx;
     }
     double n_nth = K * sum;
     plfrac = n_nth / eldens;
@@ -333,9 +333,9 @@ double injection_mixed_int(double x, void* pars) {
         return nth * std::pow(mom_int, 2.) * std::exp(-x / theta_temp);
     } else if (x < gamma_max) {
         return nth * std::pow(mom_int, 2.) * std::exp(-x / theta_temp) +
-               npl * std::pow(mom_int, -s_index) * std::exp(-mom_int / cutoff) * std::exp(-mom_cuton / mom_int);
+               npl * std::pow(mom_int, -s_index) * std::exp(-mom_int / cutoff) * std::exp(-pow(mom_cuton / mom_int, 3));
     } else {
-        return npl * std::pow(mom_int, -s_index) * std::exp(-mom_int / cutoff) * std::exp(-mom_cuton / mom_int);
+        return npl * std::pow(mom_int, -s_index) * std::exp(-mom_int / cutoff) * std::exp(-pow(mom_cuton / mom_int, 3));
     }
 }
 

--- a/src/Mixed.cpp
+++ b/src/Mixed.cpp
@@ -48,13 +48,13 @@ void Mixed::set_p(double gmax) {
 
 void Mixed::set_ndens() {
     for (size_t i = 0; i < p.size(); i++) {
-        if (p[i] <= pmin_pl / 10) {
+        if (p[i] <= pmin_pl) {
             ndens[i] = thnorm * std::pow(p[i], 2.) * std::exp(-gamma[i] / theta);
         } else if (p[i] < pmax_th) {
             ndens[i] = thnorm * std::pow(p[i], 2.) * std::exp(-gamma[i] / theta) +
-                       plnorm * std::pow(p[i], -pspec) * std::exp(-p[i] / pmax_pl) * std::exp(-std::pow(pmin_pl / p[i], 3));
+                       plnorm * std::pow(p[i], -pspec) * std::exp(-p[i] / pmax_pl);
         } else {
-            ndens[i] = plnorm * std::pow(p[i], -pspec) * std::exp(-p[i] / pmax_pl) * std::exp(-std::pow(pmin_pl / p[i], 3));
+            ndens[i] = plnorm * std::pow(p[i], -pspec) * std::exp(-p[i] / pmax_pl);
         }
     }
     initialize_gdens();
@@ -88,14 +88,14 @@ void Mixed::set_plfrac(double Le, double r, double eldens) {
     double sum = 0;
     double dx = std::log10(gamma[2] / gamma[1]);
     for (size_t i = 0; i < p.size(); i++) {
-        sum += std::log(10.) * std::pow(gamma[i], -pspec + 2.) * std::exp(-gamma[i] / gpmax) * std::exp(-std::pow(gpmin / gamma[i], 3)) * dx;
+        sum += std::log(10.) * std::pow(gamma[i], -pspec + 2.) * std::exp(-gamma[i] / gpmax) * dx;
     }
     double Ue = Le / (constants::pi * r * r * constants::cee);
     double K = std::max(Ue / (sum * mass_gr * constants::cee * constants::cee), 0.);
 
     sum = 0.;
     for (size_t i = 0; i < gamma.size(); i++) {
-        sum += std::log(10.) * std::pow(gamma[i], -pspec + 1.) * std::exp(-gamma[i] / gpmax) * std::exp(-std::pow(gpmin / gamma[i], 3)) * dx;
+        sum += std::log(10.) * std::pow(gamma[i], -pspec + 1.) * std::exp(-gamma[i] / gpmax) * dx;
     }
     double n_nth = K * sum;
     plfrac = n_nth / eldens;
@@ -327,15 +327,15 @@ double injection_mixed_int(double x, void* pars) {
     double cutoff = params->cutoff;
 
     double mom_int = std::pow(std::pow(x, 2.) - 1., 1. / 2.) * mass * constants::cee;
-    double mom_cuton = std::pow(std::pow(gamma_max, 2.) - 1., 1. / 2.) * mass * constants::cee;
+    // double mom_cuton = std::pow(std::pow(gamma_max, 2.) - 1., 1. / 2.) * mass * constants::cee;
 
-    if (x <= gamma_min / 10) {
+    if (x <= gamma_min) {
         return nth * std::pow(mom_int, 2.) * std::exp(-x / theta_temp);
     } else if (x < gamma_max) {
         return nth * std::pow(mom_int, 2.) * std::exp(-x / theta_temp) +
-               npl * std::pow(mom_int, -s_index) * std::exp(-mom_int / cutoff) * std::exp(-pow(mom_cuton / mom_int, 3));
+               npl * std::pow(mom_int, -s_index) * std::exp(-mom_int / cutoff);
     } else {
-        return npl * std::pow(mom_int, -s_index) * std::exp(-mom_int / cutoff) * std::exp(-pow(mom_cuton / mom_int, 3));
+        return npl * std::pow(mom_int, -s_index) * std::exp(-mom_int / cutoff);
     }
 }
 

--- a/src/Mixed.cpp
+++ b/src/Mixed.cpp
@@ -310,6 +310,8 @@ void Mixed::test() {
     std::cout << "Number density: " << count_particles() << std::endl;
     std::cout << "Thermal monetum limits: " << pmin_th << " " << pmax_th << std::endl;
     std::cout << "Non-thermal momentum limits: " << pmin_pl << " " << pmax_pl << std::endl;
+    std::cout << "Thermal norm: " << thnorm << std::endl;
+    std::cout << "Non-thermal norm: " << plnorm << std::endl;
 }
 
 //! Injection function to be integrated in cooling

--- a/src/Mixed.cpp
+++ b/src/Mixed.cpp
@@ -317,24 +317,25 @@ void Mixed::test() {
 //! Injection function to be integrated in cooling
 double injection_mixed_int(double x, void* pars) {
     InjectionMixedParams* params = static_cast<InjectionMixedParams*>(pars);
-    double s = params->s;
-    double t = params->t;
+    double s_index = params->s;
+    double theta_temp = params->t;
     double nth = params->nth;
     double npl = params->npl;
-    double m = params->m;
-    double min = params->min;
-    double max = params->max;
+    double mass = params->m;
+    double gamma_min = params->min;
+    double gamma_max = params->max;
     double cutoff = params->cutoff;
 
-    double mom_int = std::pow(std::pow(x, 2.) - 1., 1. / 2.) * m * constants::cee;
+    double mom_int = std::pow(std::pow(x, 2.) - 1., 1. / 2.) * mass * constants::cee;
+    double mom_cuton = std::pow(std::pow(gamma_max, 2.) - 1., 1. / 2.) * mass * constants::cee;
 
-    if (x <= min / 10) {
-        return nth * std::pow(mom_int, 2.) * std::exp(-x / t);
-    } else if (x < max) {
-        return nth * std::pow(mom_int, 2.) * std::exp(-x / t) +
-               npl * std::pow(mom_int, -s) * std::exp(-mom_int / cutoff) * std::exp(-max / mom_int);
+    if (x <= gamma_min / 10) {
+        return nth * std::pow(mom_int, 2.) * std::exp(-x / theta_temp);
+    } else if (x < gamma_max) {
+        return nth * std::pow(mom_int, 2.) * std::exp(-x / theta_temp) +
+               npl * std::pow(mom_int, -s_index) * std::exp(-mom_int / cutoff) * std::exp(-mom_cuton / mom_int);
     } else {
-        return npl * std::pow(mom_int, -s) * std::exp(-mom_int / cutoff) * std::exp(-max / mom_int);
+        return npl * std::pow(mom_int, -s_index) * std::exp(-mom_int / cutoff) * std::exp(-mom_cuton / mom_int);
     }
 }
 

--- a/src/Mixed.cpp
+++ b/src/Mixed.cpp
@@ -66,7 +66,7 @@ void Mixed::set_ndens() {
 void Mixed::set_temp_kev(double T) {
     Temp = T;
     theta = T * constants::kboltz_kev2erg / (mass_gr * constants::cee * constants::cee);
-    double emin_th = (1. / 100.) * T;
+    double emin_th = 1e-4 * T;
     double emax_th = 20. * T;
     double gmin_th, gmax_th;
 

--- a/src/Mixed.cpp
+++ b/src/Mixed.cpp
@@ -58,7 +58,7 @@ void Mixed::set_ndens() {
         }
     }
     initialize_gdens();
-    gdens_differentiate();
+    differentiate();
 }
 
 //! methods to set the temperature, pl fraction, and normalizations. Temperature
@@ -158,7 +158,7 @@ void Mixed::cooling_steadystate(double ucom, double n0, double bfield, double r,
         ndens[i] = ndens[i] / renorm;
     }
     initialize_gdens();
-    gdens_differentiate();
+    differentiate();
 }
 
 //! Method to calculate maximum momentum of non thermal particles based on

--- a/src/Mixed.cpp
+++ b/src/Mixed.cpp
@@ -52,9 +52,9 @@ void Mixed::set_ndens() {
             ndens[i] = thnorm * std::pow(p[i], 2.) * std::exp(-gamma[i] / theta);
         } else if (p[i] < pmax_th) {
             ndens[i] = thnorm * std::pow(p[i], 2.) * std::exp(-gamma[i] / theta) +
-                       plnorm * std::pow(p[i], -pspec) * std::exp(-p[i] / pmax_pl);
+                       plnorm * std::pow(p[i], -pspec) * std::exp(-p[i] / pmax_pl) * std::exp(-pmin_pl / p[i]);
         } else {
-            ndens[i] = plnorm * std::pow(p[i], -pspec) * std::exp(-p[i] / pmax_pl);
+            ndens[i] = plnorm * std::pow(p[i], -pspec) * std::exp(-p[i] / pmax_pl) * std::exp(-pmin_pl / p[i]);
         }
     }
     initialize_gdens();
@@ -83,17 +83,19 @@ void Mixed::set_plfrac(double f) { plfrac = f; }
 void Mixed::set_plfrac(double Le, double r, double eldens) {
     double gpmax =
         sqrt(pmax_pl * pmax_pl / (mass_gr * constants::cee * mass_gr * constants::cee) + 1.);
+    double gpmin =
+        sqrt(pmin_pl * pmin_pl / (mass_gr * constants::cee * mass_gr * constants::cee) + 1.);
     double sum = 0;
     double dx = std::log10(gamma[2] / gamma[1]);
     for (size_t i = 0; i < p.size(); i++) {
-        sum += std::log(10.) * std::pow(gamma[i], -pspec + 2.) * std::exp(-gamma[i] / gpmax) * dx;
+        sum += std::log(10.) * std::pow(gamma[i], -pspec + 2.) * std::exp(-gamma[i] / gpmax) * std::exp(-gpmin / gamma[i]) * dx;
     }
     double Ue = Le / (constants::pi * r * r * constants::cee);
     double K = std::max(Ue / (sum * mass_gr * constants::cee * constants::cee), 0.);
 
     sum = 0.;
     for (size_t i = 0; i < gamma.size(); i++) {
-        sum += std::log(10.) * std::pow(gamma[i], -pspec + 1.) * std::exp(-gamma[i] / gpmax) * dx;
+        sum += std::log(10.) * std::pow(gamma[i], -pspec + 1.) * std::exp(-gamma[i] / gpmax) * std::exp(-gpmin / gamma[i]) * dx;
     }
     double n_nth = K * sum;
     plfrac = n_nth / eldens;
@@ -328,9 +330,9 @@ double injection_mixed_int(double x, void* pars) {
         return nth * std::pow(mom_int, 2.) * std::exp(-x / t);
     } else if (x < max) {
         return nth * std::pow(mom_int, 2.) * std::exp(-x / t) +
-               npl * std::pow(mom_int, -s) * std::exp(-mom_int / cutoff);
+               npl * std::pow(mom_int, -s) * std::exp(-mom_int / cutoff) * std::exp(-max / mom_int);
     } else {
-        return npl * std::pow(mom_int, -s) * std::exp(-mom_int / cutoff);
+        return npl * std::pow(mom_int, -s) * std::exp(-mom_int / cutoff) * std::exp(-max / mom_int);
     }
 }
 

--- a/src/Particles.cpp
+++ b/src/Particles.cpp
@@ -11,7 +11,7 @@
 namespace kariba {
 
 Particles::Particles(size_t size)
-    : p(size, 0.0), ndens(size, 0.0), gamma(size, 0.0), gdens(size, 0.0), gdens_diff(size, 0.0) {}
+    : p(size, 0.0), ndens(size, 0.0), gamma(size, 0.0), gdens(size, 0.0), pdensp2_diff_logp(size, 0.0) {}
 
 //! Simple numerical integrals /w trapeze method
 double Particles::count_particles() {
@@ -106,19 +106,19 @@ void Particles::differentiate() {
 
         if (i == 0) {
             // Forward difference
-            d_lnf_d_lnp = safe_log(pdens[1]/pdens[0] * std::pow(p[0]/p[1], power)) /
+            d_lnf_d_lnp = safe_log(ndens[1]/ndens[0] * std::pow(p[0]/p[1], power)) /
                           safe_log(p[1]/p[0]);
         } else if (i == size - 1) {
             // Backward difference
-            d_lnf_d_lnp = safe_log(pdens[size-1]/pdens[size-2] * std::pow(p[size-2]/p[size-1], power)) /
+            d_lnf_d_lnp = safe_log(ndens[size-1]/ndens[size-2] * std::pow(p[size-2]/p[size-1], power)) /
                           safe_log(p[size-1]/p[size-2]);
         } else {
             // Centered difference in log-log space
-            d_lnf_d_lnp = safe_log(pdens[i+1]/pdens[i-1] * std::pow(p[i-1]/p[i+1], power)) /
+            d_lnf_d_lnp = safe_log(ndens[i+1]/ndens[i-1] * std::pow(p[i-1]/p[i+1], power)) /
                           safe_log(p[i+1]/p[i-1]);
         }
 
-        pdensp2_diff_logp[i] = (pdens[i]/std::pow(p[i], power)) * d_lnf_d_lnp;
+        pdensp2_diff_logp[i] = (ndens[i]/std::pow(p[i], power)) * d_lnf_d_lnp;
         pdensp2_diff_logp[i] *= std::pow(mass_gr * constants::cee, 3);
     }
 }

--- a/src/Particles.cpp
+++ b/src/Particles.cpp
@@ -101,7 +101,7 @@ void Particles::differentiate() {
     };
 
     for (size_t i = 0; i < size; i++) {
-        double d_lnf_d_lnp;
+        double d_lnf_d_lnp; // f = dn/dp * p^-2, as in syn. absorption coefficient
         double power = 2.;
 
         if (i == 0) {
@@ -119,7 +119,8 @@ void Particles::differentiate() {
         }
 
         pdensp2_diff_logp[i] = (ndens[i]/std::pow(p[i], power)) * d_lnf_d_lnp;
-        pdensp2_diff_logp[i] *= std::pow(mass_gr * constants::cee, 3);
+        // multiply later, this is in p = rho * m_e * c
+        // pdensp2_diff_logp[i] *= std::pow(mass_gr * constants::cee, 3);
     }
 }
 

--- a/src/Particles.cpp
+++ b/src/Particles.cpp
@@ -73,21 +73,56 @@ void Particles::initialize_pdens() {
     }
 }
 
-void Particles::gdens_differentiate() {
-    std::vector<double> temp;
-    size_t size = gdens.size();
+// void Particles::gdens_differentiate() {
+//     std::vector<double> temp;
+//     size_t size = gdens.size();
+
+//     for (size_t i = 0; i < size; i++) {
+//         temp.push_back(gdens[i] / (std::pow(gamma[i], 1.)));
+//     }
+
+//     for (size_t i = 0; i < size - 1; i++) {
+//         gdens_diff[i] = (temp[i + 1] - temp[i]) /
+//                         (mass_gr * std::pow(constants::cee, 2.) * (gamma[i + 1] - gamma[i]));
+//     }
+
+//     gdens_diff[size - 1] = gdens_diff[size - 2];
+// }
+
+void Particles::differentiate() {
+    const size_t size = gdens.size();
+
+    // Work in log space.  Guard against zero/negative gdens with a floor
+    // (should not occur for physical distributions, but avoids log(0)).
+    const double floor_val = 1e-300;
+
+    auto safe_log = [&](double x) -> double {
+        return std::log(std::max(x, floor_val));
+    };
 
     for (size_t i = 0; i < size; i++) {
-        temp.push_back(gdens[i] / (std::pow(gamma[i], 1.)));
-    }
+        double d_lnf_d_lnp;
+        double power = 2.;
 
-    for (size_t i = 0; i < size - 1; i++) {
-        gdens_diff[i] = (temp[i + 1] - temp[i]) /
-                        (mass_gr * std::pow(constants::cee, 2.) * (gamma[i + 1] - gamma[i]));
-    }
+        if (i == 0) {
+            // Forward difference
+            d_lnf_d_lnp = safe_log(pdens[1]/pdens[0] * std::pow(p[0]/p[1], power)) /
+                          safe_log(p[1]/p[0]);
+        } else if (i == size - 1) {
+            // Backward difference
+            d_lnf_d_lnp = safe_log(pdens[size-1]/pdens[size-2] * std::pow(p[size-2]/p[size-1], power)) /
+                          safe_log(p[size-1]/p[size-2]);
+        } else {
+            // Centered difference in log-log space
+            d_lnf_d_lnp = safe_log(pdens[i+1]/pdens[i-1] * std::pow(p[i-1]/p[i+1], power)) /
+                          safe_log(p[i+1]/p[i-1]);
+        }
 
-    gdens_diff[size - 1] = gdens_diff[size - 2];
+        pdensp2_diff_logp[i] = (pdens[i]/std::pow(p[i], power)) * d_lnf_d_lnp;
+        pdensp2_diff_logp[i] *= std::pow(mass_gr * constants::cee, 3);
+    }
 }
+
 
 void Particles::set_mass(double m) {
     mass_gr = m;

--- a/src/Powerlaw.cpp
+++ b/src/Powerlaw.cpp
@@ -53,7 +53,7 @@ void Powerlaw::set_ndens() {
         ndens[i] = plnorm * std::pow(p[i], -pspec) * std::exp(-p[i] / pmax);
     }
     initialize_gdens();
-    gdens_differentiate();
+    differentiate();
 }
 
 //! methods to set the slope and normalization
@@ -126,7 +126,7 @@ void Powerlaw::cooling_steadystate(double ucom, double n0, double bfield, double
     }
 
     initialize_gdens();
-    gdens_differentiate();
+    differentiate();
 }
 
 //! Method to calculate maximum momentum of non thermal particles based on

--- a/src/Thermal.cpp
+++ b/src/Thermal.cpp
@@ -43,7 +43,7 @@ void Thermal::set_ndens() {
         ndens[i] = thnorm * std::pow(p[i], 2.) * std::exp(-gamma[i] / theta);
     }
     initialize_gdens();
-    gdens_differentiate();
+    differentiate();
 }
 
 //! methods to set the temperature and normalization. NOTE: temperature must be

--- a/src/kariba/Cyclosyn.hpp
+++ b/src/kariba/Cyclosyn.hpp
@@ -37,8 +37,9 @@ class Cyclosyn : public Radiation {
 
     const std::vector<double>& get_cyclosyn_absorption_rate() const { return cyclosyn_absorption_rate; }
 
-    friend double cyclosyn_emis(double gamma, void* pars);
-    friend double cyclosyn_abs(double gamma, void* pars);
+    friend double cyclosyn_kernel(double gamma, double nu, double b, gsl_spline* syn, gsl_interp_accel* acc_syn);
+    friend double cyclosyn_emis(double log_gamma, void* pars);
+    friend double cyclosyn_abs(double log_gamma, void* pars);
 };
 
 }    // namespace kariba

--- a/src/kariba/Particles.hpp
+++ b/src/kariba/Particles.hpp
@@ -82,8 +82,8 @@ class Particles {
     std::vector<double> ndens;    //!< array of number density per unit volume, per unit momentum
     std::vector<double> gamma;    //!< array of particle kinetic energies for each momentum
     std::vector<double> gdens;    //!< array of number density per unit volume, per unit gamma
-    std::vector<double> gdens_diff;    //!< array with differential of number
-                                       //!< density for radiation calculation
+    std::vector<double> pdensp2_diff_logp;    //!< array with differential of number
+                                       //!< density for radiation calculation p^-2*dn/dp
 
   public:
     Particles(size_t size);
@@ -91,7 +91,7 @@ class Particles {
     virtual void set_mass(double m);
     virtual void initialize_gdens();
     virtual void initialize_pdens();
-    virtual void gdens_differentiate();
+    virtual void differentiate();
 
     virtual const std::vector<double>& get_p() const { return p; }
 
@@ -101,7 +101,7 @@ class Particles {
 
     virtual const std::vector<double>& get_gdens() const { return gdens; }
 
-    virtual const std::vector<double>& get_gdens_diff() const { return gdens_diff; }
+    virtual const std::vector<double>& get_pdensp2_diff_logp() const { return pdensp2_diff_logp; }
 
     virtual double count_particles();
     virtual double count_particles_energy();


### PR DESCRIPTION
This update tackles the following points:

- pitch-angle averaging:
  - changes the function F(x) to it's pitch-angle averaged version (small difference expected)
  - changes the critical frequency (no longer a fixed pitch-angle sin(alpha)=1, as inconsistent with average angle elsewhere, but now fully averaged)
- absorption coefficient
  - fixed the wrong dependence in derivative of electron spectrum (moving a factor gamma into the derivative)
  - fixed the wrong factors gamma vs rho/p
  - shifted derivative to momentum space and changed to central differencing scheme
- tau calculation
  - fixed bad Taylor expansion if `(tsyn >= 1.)`  should be something << 1, better to use `std::expm1`
  - fixed that any geometry gets doppler factor instead of just cylindrical
  - fixed counterjet to `dopfac_cj`
  
For readability it also extracts the synchrotron kernel into a separate function. Also renamed the function `gdens_differentiate` to `differentiate` (and the corresponding array `gdens_diff` to `pdensp2_diff_logp`) for clarity.

In the BlackBody class, the thermal power-law tail at low energies is extended a little bit, and code redundancy is reduced by delegating functions.