### PR TITLE
Fixing tests/examples after cyclosyn update PR

### DIFF
--- a/examples/corona.cpp
+++ b/examples/corona.cpp
@@ -102,7 +102,7 @@ int main() {
     gsl_spline_init(spline_eldis, elec_Tau260Te90.get_gamma().data(),
                     elec_Tau260Te90.get_gdens().data(), nel);
     gsl_spline_init(spline_deriv, elec_Tau260Te90.get_gamma().data(),
-                    elec_Tau260Te90.get_gdens_diff().data(), nel);
+                    elec_Tau260Te90.get_pdensp2_diff_logp().data(), nel);
 
     // Set up the inverse Compton calculation. As usual, you need to do some
     // book-keeping before running the code. The constructor this time requires
@@ -153,7 +153,7 @@ int main() {
     gsl_spline_init(spline_eldis, elec_Tau076Te90.get_gamma().data(),
                     elec_Tau076Te90.get_gdens().data(), nel);
     gsl_spline_init(spline_deriv, elec_Tau076Te90.get_gamma().data(),
-                    elec_Tau076Te90.get_gdens_diff().data(), nel);
+                    elec_Tau076Te90.get_pdensp2_diff_logp().data(), nel);
 
     kariba::Compton IC_Tau076Te90(nfreq, 50);
     IC_Tau076Te90.set_frequency(1e15, 1e22);
@@ -180,7 +180,7 @@ int main() {
     gsl_spline_init(spline_eldis, elec_Tau019Te90.get_gamma().data(),
                     elec_Tau019Te90.get_gdens().data(), nel);
     gsl_spline_init(spline_deriv, elec_Tau019Te90.get_gamma().data(),
-                    elec_Tau019Te90.get_gdens_diff().data(), nel);
+                    elec_Tau019Te90.get_pdensp2_diff_logp().data(), nel);
 
     kariba::Compton IC_Tau019Te90(nfreq, 50);
     IC_Tau019Te90.set_frequency(1e15, 1e22);
@@ -207,7 +207,7 @@ int main() {
     gsl_spline_init(spline_eldis, elec_Tau260Te900.get_gamma().data(),
                     elec_Tau260Te900.get_gdens().data(), nel);
     gsl_spline_init(spline_deriv, elec_Tau260Te900.get_gamma().data(),
-                    elec_Tau260Te900.get_gdens_diff().data(), nel);
+                    elec_Tau260Te900.get_pdensp2_diff_logp().data(), nel);
 
     kariba::Compton IC_Tau260Te900(nfreq, 50);
     IC_Tau260Te900.set_frequency(1e15, 1e22);
@@ -234,7 +234,7 @@ int main() {
     gsl_spline_init(spline_eldis, elec_Tau076Te900.get_gamma().data(),
                     elec_Tau076Te900.get_gdens().data(), nel);
     gsl_spline_init(spline_deriv, elec_Tau076Te900.get_gamma().data(),
-                    elec_Tau076Te900.get_gdens_diff().data(), nel);
+                    elec_Tau076Te900.get_pdensp2_diff_logp().data(), nel);
 
     kariba::Compton IC_Tau076Te900(nfreq, 50);
     IC_Tau076Te900.set_frequency(1e15, 1e22);
@@ -261,7 +261,7 @@ int main() {
     gsl_spline_init(spline_eldis, elec_Tau019Te900.get_gamma().data(),
                     elec_Tau019Te900.get_gdens().data(), nel);
     gsl_spline_init(spline_deriv, elec_Tau019Te900.get_gamma().data(),
-                    elec_Tau019Te900.get_gdens_diff().data(), nel);
+                    elec_Tau019Te900.get_pdensp2_diff_logp().data(), nel);
 
     kariba::Compton IC_Tau019Te900(nfreq, 50);
     IC_Tau019Te900.set_frequency(1e15, 1e22);

--- a/examples/singlezone.cpp
+++ b/examples/singlezone.cpp
@@ -83,7 +83,7 @@ int main() {
                Electrons.get_gdens(), "Output/Singlezone_Particles.dat");
 
     gsl_spline_init(spline_eldis, Electrons.get_gamma().data(), Electrons.get_gdens().data(), nel);
-    gsl_spline_init(spline_deriv, Electrons.get_gamma().data(), Electrons.get_gdens_diff().data(),
+    gsl_spline_init(spline_deriv, Electrons.get_gamma().data(), Electrons.get_pdensp2_diff_logp().data(),
                     nel);
 
     // Set up the cyclo-synchrotron emission, by specifying the size of the

--- a/tests/test_compton.cpp
+++ b/tests/test_compton.cpp
@@ -49,7 +49,7 @@ TEST_CASE("Integration tests - Complete workflows") {
         gsl_spline_init(spline_eldis, electrons.get_gamma().data(), electrons.get_gdens().data(),
                         nel);
         gsl_spline_init(spline_deriv, electrons.get_gamma().data(),
-                        electrons.get_gdens_diff().data(), nel);
+                        electrons.get_pdensp2_diff_logp().data(), nel);
 
         // Calculate synchrotron emission
         kariba::Cyclosyn syncro(nfreq);

--- a/tests/test_cyclosyn.cpp
+++ b/tests/test_cyclosyn.cpp
@@ -48,7 +48,7 @@ TEST_CASE("Integration tests - Complete workflows") {
         gsl_spline_init(spline_eldis, electrons.get_gamma().data(), electrons.get_gdens().data(),
                         nel);
         gsl_spline_init(spline_deriv, electrons.get_gamma().data(),
-                        electrons.get_gdens_diff().data(), nel);
+                        electrons.get_pdensp2_diff_logp().data(), nel);
 
         // Calculate synchrotron emission
         kariba::Cyclosyn syncro(nfreq);

--- a/tests/test_distributions.cpp
+++ b/tests/test_distributions.cpp
@@ -51,7 +51,7 @@ TEST_CASE("Integration tests - Complete workflows") {
         gsl_spline_init(spline_eldis, electrons.get_gamma().data(), electrons.get_gdens().data(),
                         nel);
         gsl_spline_init(spline_deriv, electrons.get_gamma().data(),
-                        electrons.get_gdens_diff().data(), nel);
+                        electrons.get_pdensp2_diff_logp().data(), nel);
 
         // Calculate synchrotron emission
         kariba::Cyclosyn syncro(nfreq);

--- a/tests/test_radiation.cpp
+++ b/tests/test_radiation.cpp
@@ -142,7 +142,7 @@ TEST_CASE("Synchrotron radiation") {
         gsl_spline_init(spline_eldis, electrons.get_gamma().data(), electrons.get_gdens().data(),
                         100);
         gsl_spline_init(spline_deriv, electrons.get_gamma().data(),
-                        electrons.get_gdens_diff().data(), 100);
+                        electrons.get_pdensp2_diff_logp().data(), 100);
 
         SUBCASE("Basic synchrotron setup") {
             double bfield = 1e3;     // Gauss
@@ -301,7 +301,7 @@ TEST_CASE("Inverse Compton scattering") {
         gsl_spline_init(spline_eldis, electrons.get_gamma().data(), electrons.get_gdens().data(),
                         100);
         gsl_spline_init(spline_deriv, electrons.get_gamma().data(),
-                        electrons.get_gdens_diff().data(), 100);
+                        electrons.get_pdensp2_diff_logp().data(), 100);
 
         double gmin = electrons.get_gamma()[0];
         double gmax_actual = electrons.get_gamma()[99];


### PR DESCRIPTION
Fixed the updated name also in the tests and examples

The problem is I renamed `gdens_diff` to `pdensp2_diff_logp` as it is not the derivative dn/dgamma but d/dlogp [ p^-2 dn/dp]. This was wrongly implemented before, but only matters in the non-relativistic regime.
Thus I also changed the getter from `get_gdens_diff` to `get_pdensp2_diff_logp`.
This is a bit tricky because everytime you do jetmain you use this function, and also in the tests to init the interpolation over these derivatives to give them then to the `Cyclosyn` class.

For now I just fixed the tests+examples, but backwards compatibility might be a small issue.